### PR TITLE
Added correct language for event calendar

### DIFF
--- a/mod/wet4/languages/en.php
+++ b/mod/wet4/languages/en.php
@@ -1521,6 +1521,9 @@ Please do not reply to this email.",
 	'event_calendar_contact' => "You are not the contact person?",
 	"event_calendar:email" => "E-mail address",
 	"event_calendar:phone" => "Phone number",
+    'event_calendar:lang:french'=>"French",
+    'event_calendar:lang:english'=>"English",
+    'event_calendar:lang:bilingual'=>"Bilingual",
 
     /*new for tour*/
 'gcTour:next' => 'Next ',

--- a/mod/wet4/languages/fr.php
+++ b/mod/wet4/languages/fr.php
@@ -1390,6 +1390,9 @@ return array(
 'event_calendar_contact' => "Vous n'êtes pas la personne contact?",
 "event_calendar:email" => "Adresse courriel",
 "event_calendar:phone" => "Numéro de téléphone",
+'event_calendar:lang:french'=>"Français",
+'event_calendar:lang:english'=>"Anglais",
+'event_calendar:lang:bilingual'=>"Bilingue",
 
 /*Change access*/
 

--- a/mod/wet4/views/default/forms/event_calendar/edit.php
+++ b/mod/wet4/views/default/forms/event_calendar/edit.php
@@ -55,9 +55,9 @@ $schedule_options = array(
 );
 
 $language_options = array(
-	elgg_echo('Français'),
-	elgg_echo('English'),
-	elgg_echo('Bilingue'),
+	elgg_echo('event_calendar:lang:french'),
+	elgg_echo('event_calendar:lang:english'),
+	elgg_echo('event_calendar:lang:bilingual'),
 );
 
 if (elgg_is_active_plugin('event_poll')) {


### PR DESCRIPTION
Choosing event language should now display in the proper language. Closes #719 