### PR TITLE
Group operators can now change and remove the cover photo

### DIFF
--- a/mod/gc_group_layout/actions/groups/edit.php
+++ b/mod/gc_group_layout/actions/groups/edit.php
@@ -233,8 +233,8 @@ if(reset($c_photo) ){
 
     $c_photo_guid = $filehandler2->getGUID();
     $subtype_testing = $filehandler2->getSubtype();
-   $group->cover_photo =$c_photo_guid; //Nick - Set Cover photo metadata
-}else if(isset($group->cover_photo) && $group->cover_photo !='nope'){
+   $group->cover_photo = 'yessir'; //Nick - Yes there is a cover photo. Changed from the photo guid as this was not being set when a group admin / operator was trying to change the cover photo
+}else if(isset($group->cover_photo) && $group->cover_photo !=='nope'){
 
 }else{
 $group->cover_photo = 'nope';


### PR DESCRIPTION
Group admins/ operators can now also modify the group cover photo. Fixes gctools-outilsgc/gcconnex#708