### PR TITLE
Order work experience and education items

### DIFF
--- a/mod/b_extended_profile/views/default/b_extended_profile/edit_education.php
+++ b/mod/b_extended_profile/views/default/b_extended_profile/edit_education.php
@@ -7,7 +7,7 @@
  */
 
 //This is an Ajax call
-if (elgg_is_xhr()) {  
+if (elgg_is_xhr()) {
     $user_guid = $_GET["guid"];
     $user = get_user($user_guid);
 
@@ -31,6 +31,7 @@ if (elgg_is_xhr()) {
 
     // handle $education_guid differently depending on whether it's an array or not
     if (is_array($education_guid)) {
+        usort($education_guid, "sortDate");
         foreach ($education_guid as $guid) { // display the input/education view for each education entry
             if ( $guid != null ) {
                 echo elgg_view('input/education', array('guid' => $guid));

--- a/mod/b_extended_profile/views/default/b_extended_profile/edit_work-experience.php
+++ b/mod/b_extended_profile/views/default/b_extended_profile/edit_work-experience.php
@@ -29,7 +29,7 @@ if (elgg_is_xhr()) {  //This is an Ajax call!
     echo '<div class="gcconnex-work-experience-all">';
     // handle $work_experience_guid differently depending on whether it's an array or not
     if (is_array($work_experience_guid)) {
-        //usort($work_experience_guid, "sortDate");
+        usort($work_experience_guid, "sortDate");
         foreach ($work_experience_guid as $guid) { // display the input/work-experience view for each work experience entry
             if ( $guid != null ) {
                 echo elgg_view('input/work-experience', array('guid' => $guid));

--- a/mod/b_extended_profile/views/default/b_extended_profile/work-experience.php
+++ b/mod/b_extended_profile/views/default/b_extended_profile/work-experience.php
@@ -19,14 +19,14 @@ else {
         $work_experience_guid = array($work_experience_guid);
     }
 
-   // usort($work_experience_guid, "sortDate");
+    usort($work_experience_guid, "sortDate");
 
     foreach ($work_experience_guid as $guid) {
 
         if ($experience = get_entity($guid)) {
             echo '<div class="gcconnex-profile-label work-experience-title">' . $experience->title . '</div>';
             echo '<div class="gcconnex-profile-label work-experience-organization">' . $experience->organization . '</div>';
-            
+
             $cal_month = array(
                 1 => elgg_echo('gcconnex_profile:month:january'),
                 2 => elgg_echo('gcconnex_profile:month:february'),
@@ -53,7 +53,7 @@ else {
             echo '</div>';
             echo '<div class="gcconnex-profile-label work-experience-responsibilities mrgn-tp-md">' . $experience->responsibilities . '</div>';
             echo '<div class="gcconnex-profile-label work-experience-colleagues">';
-            
+
             $colleagues = $experience->colleagues;
             if (!(is_array($colleagues))) {
                 $colleagues = array($colleagues);


### PR DESCRIPTION
Work experiebce and education items now sort in order of newest to
oldest based on end date. When a user edits their work experience or
education, the items will be listed in the same order as they were
shown.

Closes #774 