### PR TITLE
removes description unless it contains no html

### DIFF
--- a/mod/cp_notifications/start.php
+++ b/mod/cp_notifications/start.php
@@ -1090,10 +1090,11 @@ if (elgg_instanceof($container, 'group')) {
 					}
 				}
    
+   			$object_description = ($object->description != strip_tags($object->description)) ? "" : $object->description;
 			$message = array(
 				'cp_topic' => $object, 
 				'cp_msg_type' => 'cp_new_type',
-				'cp_topic_description' => $object->description,
+				'cp_topic_description' => $object_description,
 			);
 
 			$email_only = false;


### PR DESCRIPTION
This has been fixed in Notification Digest. We will push this if Notification Digest is decided to be delayed for production implementation.