### PR TITLE
Group member private setting

### DIFF
--- a/mod/gc_group_layout/views/default/groups/sidebar/sidebar.php
+++ b/mod/gc_group_layout/views/default/groups/sidebar/sidebar.php
@@ -12,7 +12,7 @@ $group = elgg_get_page_owner_entity();
 $display_members = $group->getPrivateSetting('group_tools:cleanup:members');
 
 //show group members based on privacy setting
-if($display_members == 'no'){
+if($display_members != 'yes'){
   echo elgg_view('groups/sidebar/group_members', $vars);
 }
 

--- a/mod/gc_group_layout/views/default/groups/sidebar/sidebar.php
+++ b/mod/gc_group_layout/views/default/groups/sidebar/sidebar.php
@@ -5,10 +5,16 @@ Group Profile Sidebar
 
 **/
 
+$group = elgg_get_page_owner_entity();
 
 //members widget
 //Nick - we will keep the members in the sidebar
-echo elgg_view('groups/sidebar/group_members', $vars);
+$display_members = $group->getPrivateSetting('group_tools:cleanup:members');
+
+//show group members based on privacy setting
+if($display_members == 'no'){
+  echo elgg_view('groups/sidebar/group_members', $vars);
+}
 
 //group activity
 echo elgg_view('groups/sidebar/activity', $vars);

--- a/mod/group_tools/actions/cleanup.php
+++ b/mod/group_tools/actions/cleanup.php
@@ -4,17 +4,17 @@
 * Group Tools
 *
 * Cleanup the group sidebar
-* 
+*
 * @author ColdTrick IT Solutions
-*/	
+*/
 
 $group_guid = (int) get_input("group_guid");
 
 $owner_block = get_input("owner_block");
 $actions = get_input("actions");
 $menu = get_input("menu");
-$ = get_input("members");
-$semembersarch = get_input("search");
+$members = get_input("members");
+$search = get_input("search");
 $featured = get_input("featured");
 $featured_sorting = get_input("featured_sorting");
 $my_status = get_input("my_status");
@@ -26,7 +26,7 @@ $group = get_entity($group_guid);
 if (!empty($group) && ($group instanceof ElggGroup)) {
 	if ($group->canEdit()) {
 		$prefix = "group_tools:cleanup:";
-		
+
 		$group->setPrivateSetting($prefix . "owner_block", $owner_block);
 		$group->setPrivateSetting($prefix . "actions", $actions);
 		$group->setPrivateSetting($prefix . "menu", $menu);
@@ -35,8 +35,8 @@ if (!empty($group) && ($group instanceof ElggGroup)) {
 		$group->setPrivateSetting($prefix . "featured", $featured);
 		$group->setPrivateSetting($prefix . "featured_sorting", $featured_sorting);
 		$group->setPrivateSetting($prefix . "my_status", $my_status);
-		
-		
+
+
 		$forward_url = $group->getURL();
 		system_message(elgg_echo("group_tools:actions:cleanup:success"));
 	} else {


### PR DESCRIPTION
Now allow user to toggle if group members displays in sidebar by using the sidebar cleanup under the admin tab in group settings.

Also fixed error with form submit when user clicked save.

Fixes #640 