### PR TITLE
Event start time should no longer duplicate

### DIFF
--- a/mod/event_calendar/models/model.php
+++ b/mod/event_calendar/models/model.php
@@ -1179,7 +1179,8 @@ function event_calendar_get_formatted_time($event) {
 					$end_date = event_calendar_format_time($end_date, $event->end_time);
 
 				}
-				$start_date = event_calendar_format_time($start_date, $event->start_time);
+                //Nick - I commented this out because it was causing the start date to appear twice
+				//$start_date = event_calendar_format_time($start_date, $event->start_time);
 			}
 			$time_bit = "$start_date - $end_date";
 


### PR DESCRIPTION
The start date of the event should now only display once.

Fixes #840 