### PR TITLE
Fix URLs from GH organization rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 
 # GCconnex
 
+[![Build Status](https://secure.travis-ci.org/gctools-outilsgc/gcconnex.svg?branch=gcconnex)](https://travis-ci.org/gctools-outilsgc/gcconnex)
 [![Join the chat at https://gitter.im/gctools-outilsgc/gcconnex](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/gctools-outilsgc/general?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 GCconnex is a professional networking and collaborative workspace for all Canadian public service, allowing people to connect and share information, leveraging the power of networking towards a more effective and efficient public service.
@@ -11,7 +12,7 @@ GCconnex is based on Elgg. https://github.com/Elgg/Elgg
 
 ## Installation
 
-Follow instructions in [INSTALL.md](https://github.com/tbs-sct/gcconnex/blob/gcconnex/INSTALL.md)
+Follow instructions in [INSTALL.md](INSTALL.md)
 
 ## Using Docker
 
@@ -35,9 +36,8 @@ use docker-compose to start/create your containers.
 
 Then visit [http://localhost:8080](http://localhost:8080) and follow the
 instructions to complete your installation.  Once the installer is complete,
-refer to
-[INSTALL.md](https://github.com/tbs-sct/gcconnex/blob/gcconnex/INSTALL.md#configure-plugins)
-to configure the plugins required by GCconnex.
+refer to [INSTALL.md](INSTALL.md#configure-plugins) to configure the plugins
+required by GCconnex.
 
 ### Docker specific configuration
 
@@ -75,7 +75,7 @@ GCconnex est basé sur Elgg. https://github.com/Elgg/Elgg
 
 ## Installation
 
-Suivez les instructions dans [INSTALL.md](https://github.com/tbs-sct/gcconnex/blob/gcconnex/INSTALL.md)
+Suivez les instructions dans [INSTALL.md](INSTALL.md)
 
 ## Utilisation de Docker
 
@@ -90,7 +90,7 @@ environnement de développement.
 
 ### Pour commencer
 
-> Le serveur apache qui fonctionne dans Docker aura besoin d'ecrire dans le dossier 
+> Le serveur apache qui fonctionne dans Docker aura besoin d'ecrire dans le dossier
 > principale et le dossier "engine".  ```chmod o+w . && chmod o+w engine```
 
 Commencez avec le téléchargement du code source de github, ensuite dans ceci
@@ -100,8 +100,7 @@ utilisez `docker-compose` pour démarrer et/ou créer vos conteneurs Docker.
 
 Ensuite, visitez [http://localhost:8080](http://localhost:8080) et suivre les
 instructions pour compléter votre installation.  Une fois complet, regarder à
-[INSTALL.md](https://github.com/tbs-sct/gcconnex/blob/gcconnex/INSTALL.md#configure-plugins)
-et suivez les étapes additionnels.
+[INSTALL.md](INSTALL.md#configure-plugins) et suivez les étapes additionnels.
 
 ### Configuration spécifique avec Docker
 
@@ -126,5 +125,3 @@ Nous vous invitons à contribuer.  Créez des billets (Issues) pour des problèm
 GNU General Public License (GPL) Version 2
 
 Elgg Copyright (c) 2008-2016, voir COPYRIGHT.txt
-
-[![Build Status](https://secure.travis-ci.org/tbs-sct/gcconnex.svg?branch=gcconnex)](https://travis-ci.org/tbs-sct/gcconnex)


### PR DESCRIPTION
- Travis Badge works again and is pulled up to the top
- Use repo relative links for the Intall.MD links