### PR TITLE
Fix for layout issues on profile

### DIFF
--- a/mod/b_extended_profile/views/default/profile/tab-content.php
+++ b/mod/b_extended_profile/views/default/profile/tab-content.php
@@ -131,7 +131,6 @@ echo '<div role="tabpanel" tabindex="-1" class="tab-pane fade-in" id="events">';
 
     foreach($events as $event) {
 		echo elgg_view("object/event_calendar", array('entity' => $event));
-        echo '</div>';
 	}
 
     $date = date('Y-m-d'/*, strtotime("-1 days")*/);


### PR DESCRIPTION
With a change to objects being in <article> tags this caused a layout issue where a <div> was getting closed too soon if the user had event calendar objects.

If a user had events on their profile they layout broke.

(There is no issue for this PR it was reported in Slack)