### PR TITLE
Correcting the tab order of the tool links

### DIFF
--- a/mod/gcconnex_theme/views/default/page/elements/site-brand.php
+++ b/mod/gcconnex_theme/views/default/page/elements/site-brand.php
@@ -24,30 +24,25 @@ if (elgg_is_active_plugin('gc_fedsearch_gsa') && ((!$gsa_usertest) && strcmp($gs
                         <span><span class="bold-gc">GC</span>connex</span>
                     </a>
                     </div>
-
-                    
                 </div>
                 <div class="col-sm-6 col-sm-offset-3 hidden-xs">
                     <?php if (!elgg_get_plugin_setting('ExtTheme', 'wet4')) {?>
                     <div id="tool-link" class="pull-right">
-                    <div class="pull-right tool-link">
+                        <div class="pull-left tool-link">
+                        <a href="<?php echo elgg_echo('wet:gcpediaLink');?>">
+                            <img class="tool-link-icon" src="<?php echo $site_url.'/mod/wet4/graphics/pedia_icon.png';?>" alt="GCpedia" /><span class="bold-gc">GC</span><?php echo elgg_echo('wet:barGCpedia');?>
+                        </a>
+                        </div>
+                        <div class="pull-left tool-link">
+                        <a href="<?php echo elgg_echo('wet:gcintranetLink-toolsHead');?>">
+                            <img class="tool-link-icon" src="<?php echo $site_url.'/mod/wet4/graphics/intranet_icon.png'?>" alt="GCintranet"/><span class="bold-gc">GC</span>intranet
+                        </a>
+                        </div>
+                        <div class="pull-left tool-link">
                         <a href="<?php echo elgg_echo('wet:gcdirectoryLink');?>">
                             <img class="tool-link-icon" src="<?php echo $site_url.'/mod/wet4/graphics/directory_icon.png'?>" alt="GCDirectory" /><span class="bold-gc">GC</span><?php echo elgg_echo('wet:barDirectory');?>
                         </a>
-
-                    </div>
-                    <div class="pull-right tool-link">
-                        <a href="<?php echo elgg_echo('wet:gcintranetLink-toolsHead');?>">
-                        <img class="tool-link-icon" src="<?php echo $site_url.'/mod/wet4/graphics/intranet_icon.png'?>" alt="GCintranet"/><span class="bold-gc">GC</span>intranet</a>
-
-                    </div>
-                    <div class="pull-right tool-link">
-                        <a href="<?php echo elgg_echo('wet:gcpediaLink');?>">
-                        <img class="tool-link-icon" src="<?php echo $site_url.'/mod/wet4/graphics/pedia_icon.png';?>" alt="GCpedia" /><span class="bold-gc">GC</span><?php echo elgg_echo('wet:barGCpedia');?></a>
-
-
-                    </div>
-
+                        </div>
                     </div>
                    <?php }?>
                 </div>


### PR DESCRIPTION
The tab order of the links to the other GCtools will now go in the correct order.