### PR TITLE
Allow no dates in education

### DIFF
--- a/mod/b_extended_profile/languages/en.php
+++ b/mod/b_extended_profile/languages/en.php
@@ -51,6 +51,7 @@ $english = array(
     'gcconnex_profile:cancel' => 'Cancel',
     'gcconnex_profile:save' => 'Save',
     'gcconnex_profile:present' => 'Present', // for work and education time ranges.. from XX date to Present
+    'gcconnex_profile:unknown' => 'Unknown', // for education time ranges when year is left empty	
     'gcconnex_profile:about_me:empty' => 'Begin entering a description about yourself by clicking "Edit" in the top right corner of this box.',// prompt to add first skill
     'gcconnex_profile:about_me:access' => 'Who can see my description',
 
@@ -69,6 +70,7 @@ $english = array(
     'gcconnex_profile:basic:save' => 'Save',
 
     // MONTHS
+	'gcconnex_profile:month:none' => '',
     'gcconnex_profile:month:january' => 'January',
     'gcconnex_profile:month:february' => 'February',
     'gcconnex_profile:month:march' => 'March',

--- a/mod/b_extended_profile/languages/fr.php
+++ b/mod/b_extended_profile/languages/fr.php
@@ -52,6 +52,7 @@ $french = array(
     'gcconnex_profile:cancel' => 'Annuler',
     'gcconnex_profile:save' => 'Sauvegarder',
     'gcconnex_profile:present' => 'Maintenant',
+	'gcconnex_profile:unknown' => 'Inconnu', // for education time ranges when year is left empty	
     'gcconnex_profile:about_me:empty' => 'Ajoutez des précisions à votre sujet en cliquant sur « Modifier » dans le coin supérieur droit de cette section.',
     'gcconnex_profile:about_me:access' => 'Accès aux renseignements à mon sujet ',
 
@@ -70,6 +71,7 @@ $french = array(
     'gcconnex_profile:basic:save' => 'Sauvegarder',
 
     // MONTHS
+	'gcconnex_profile:month:none' => '',
     'gcconnex_profile:month:january' => 'Janvier',
     'gcconnex_profile:month:february' => 'Février',
     'gcconnex_profile:month:march' => 'Mars',

--- a/mod/b_extended_profile/views/default/b_extended_profile/education.php
+++ b/mod/b_extended_profile/views/default/b_extended_profile/education.php
@@ -30,6 +30,7 @@ if ($user->canEdit() && ($education_guid == NULL || empty($education_guid))) {
             echo '<div class="gcconnex-profile-label education-degree">' . $education->degree . '<span aria-hidden="true"> - </span><span class="wb-invisible"> '.elgg_echo('profile:content:for').' </span>' . $education->field . '</div>';
 
             $cal_month = array(
+					0 => elgg_echo('gcconnex_profile:month:none'),
                     1 => elgg_echo('gcconnex_profile:month:january'),
                     2 => elgg_echo('gcconnex_profile:month:february'),
                     3 => elgg_echo('gcconnex_profile:month:march'),
@@ -43,12 +44,26 @@ if ($user->canEdit() && ($education_guid == NULL || empty($education_guid))) {
                     11 => elgg_echo('gcconnex_profile:month:november'),
                     12 => elgg_echo('gcconnex_profile:month:december')
                 );
-            echo '<div class="gcconnex-profile-label timeStamp">' . $cal_month[$education->startdate] . ', ' . $education->startyear . '<span aria-hidden="true"> - </span><span class="wb-invisible"> '.elgg_echo('profile:content:to').' </span>';
+            echo '<div class="gcconnex-profile-label timeStamp">' . $cal_month[$education->startdate] . ' ';
+			
+			if ($education->startyear != '')
+				echo $education->startyear;
+			else
+				echo elgg_echo('gcconnex_profile:unknown');
+			
+			echo  '<span aria-hidden="true"> - </span><span class="wb-invisible"> '.elgg_echo('profile:content:to').' </span>';
 
             if ($education->ongoing == 'true') {
                 echo elgg_echo('gcconnex_profile:education:present');
             } else {
-                echo $cal_month[$education->enddate] . ', ' . $education->endyear;
+                echo $cal_month[$education->enddate] . ' ';
+				
+				if ($education->endyear != '')
+					echo $education->endyear;
+				else
+					echo elgg_echo('gcconnex_profile:unknown');
+				
+
             }
             echo '</div>';
             echo '</div>';

--- a/mod/b_extended_profile/views/default/input/education.php
+++ b/mod/b_extended_profile/views/default/input/education.php
@@ -44,6 +44,7 @@ echo '<div class="gcconnex-education-entry" tabindex="-1" data-guid="' . $guid .
             'name' => 'startdate',
             'class' => 'gcconnex-education-startdate',
             'options_values' => array(
+				0 => elgg_echo('gcconnex_profile:month:none'),
                 1 => elgg_echo('gcconnex_profile:month:january'),
                 2 => elgg_echo('gcconnex_profile:month:february'),
                 3 => elgg_echo('gcconnex_profile:month:march'),
@@ -73,6 +74,7 @@ echo '<div class="gcconnex-education-entry" tabindex="-1" data-guid="' . $guid .
         'id' => 'enddate-' . $guid,
         'class' => 'gcconnex-education-enddate gcconnex-education-enddate-' . $education->guid,
         'options_values' => array(
+			0 => elgg_echo(''),
             1 => elgg_echo('gcconnex_profile:month:january'),
             2 => elgg_echo('gcconnex_profile:month:february'),
             3 => elgg_echo('gcconnex_profile:month:march'),

--- a/mod/b_extended_profile/views/default/input/languages.php
+++ b/mod/b_extended_profile/views/default/input/languages.php
@@ -20,7 +20,7 @@ echo elgg_echo('gcconnex_profile:languages:language') . elgg_view("input/text", 
 $params = array(
     'name' => 'enddate',
     'class' => 'gcconnex-education-enddate gcconnex-education-enddate-' . $education->guid,
-    'options' => array('January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'),
+    'options' => array('', 'January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'),
     'value' => $education->enddate);
 if ($education->ongoing == 'true') {
     $params['disabled'] = 'true';

--- a/mod/b_extended_profile/views/default/input/languages.php
+++ b/mod/b_extended_profile/views/default/input/languages.php
@@ -20,7 +20,7 @@ echo elgg_echo('gcconnex_profile:languages:language') . elgg_view("input/text", 
 $params = array(
     'name' => 'enddate',
     'class' => 'gcconnex-education-enddate gcconnex-education-enddate-' . $education->guid,
-    'options' => array('', 'January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'),
+    'options' => array('January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'),
     'value' => $education->enddate);
 if ($education->ongoing == 'true') {
     $params['disabled'] = 'true';

--- a/mod/gc_onboard/views/default/onboard/input/education.php
+++ b/mod/gc_onboard/views/default/onboard/input/education.php
@@ -47,6 +47,7 @@ echo '<div class="gcconnex-education-entry" data-guid="' . $guid . '">'; // educ
             'name' => 'startdate',
             'class' => 'gcconnex-education-startdate',
             'options_values' => array(
+				0 => elgg_echo('gcconnex_profile:month:none'),
                 1 => elgg_echo('gcconnex_profile:month:january'),
                 2 => elgg_echo('gcconnex_profile:month:february'),
                 3 => elgg_echo('gcconnex_profile:month:march'),
@@ -76,6 +77,7 @@ echo '<div class="gcconnex-education-entry" data-guid="' . $guid . '">'; // educ
         'id' => 'enddate-' . $guid,
         'class' => 'gcconnex-education-enddate gcconnex-education-enddate-' . $education->guid,
         'options_values' => array(
+			0 => elgg_echo(''),
             1 => elgg_echo('gcconnex_profile:month:january'),
             2 => elgg_echo('gcconnex_profile:month:february'),
             3 => elgg_echo('gcconnex_profile:month:march'),

--- a/mod/missions_profile_extend/js/endorsements/gcconnex-profile.js
+++ b/mod/missions_profile_extend/js/endorsements/gcconnex-profile.js
@@ -772,18 +772,8 @@ function saveProfile(event) {
             //start year field
             var $startyear = [];
             $('.gcconnex-education-start-year').not(":hidden").each(function() {
-              //check if field is empty
-              if($.trim($(this).val()) == ''){
-                  //report error
-                  $valid_form = false;
-                  //add error style to field
-                  $(this).addClass('input-error').attr('aria-invalid', "true");
-              } else {
-                //remove error style if active
-                $(this).removeClass('input-error').removeAttr('aria-invalid', "true");
-                //push value into array
-                $startyear.push($(this).val());
-              }
+              //push value into array
+              $startyear.push($(this).val());
             });
 
             //end month dropdown
@@ -805,8 +795,8 @@ function saveProfile(event) {
                 $endyear.push($(this).val());
               } else if($ongoing[$entry_count] == false) {
 
-                //check if empty or that end date is not a date before start date
-                if($.trim($(this).val()) == '' || $(this).val() < $startyear[$entry_count]){
+                //check if end date is not a date before start date but don't put error if end date is empty
+                if(($(this).val() < $startyear[$entry_count]) && $(this).val() != '' ){
                     //report error
                     $valid_form = false;
                     //add error style


### PR DESCRIPTION
Fixes issue https://github.com/gctools-outilsgc/gcconnex/issues/564

 I also added an empty row in the month selection as the month might also be unknown. I removed the comma between month and year because it didn't look good if both the year and month is missing.

I tested adding no end year, no start year, and both no end year and no start year. The check that start year is BEFORE end year also still works.

When there is no year information, it prints Unknown in English and Inconnu in French

I am not familiar with the possible ramifications with Missions so this may need to be tested.

![education - fr](https://cloud.githubusercontent.com/assets/8117634/24812648/e5da032c-1b98-11e7-92f2-5217d9a3677c.png)

![education - en](https://cloud.githubusercontent.com/assets/8117634/24812652/ea00a37a-1b98-11e7-923c-c2719b083a66.png)
