### PR TITLE
WET4 plugin - Missing/hidden content caused by a following panel header

### DIFF
--- a/mod/wet4/views/default/page/components/image_block.php
+++ b/mod/wet4/views/default/page/components/image_block.php
@@ -153,13 +153,15 @@ if ($alt_image) {
 
 echo <<<HTML
 
-<article class="$class clearfix mrgn-bttm-sm" $id>
+<article class="$class mrgn-bttm-sm" $id>
 
 	$image$alt_image$body$echo
-    <div class=" elgg-body clearfix edit-comment">
+    <div class="clearfix"></div>
+    <div class=" elgg-body edit-comment">
    
     </div>
 </article>
+<div class="clearfix"></div>
 HTML;
 
 }


### PR DESCRIPTION
The content get hidden if the following element is a panel.

fix https://github.com/gctools-outilsgc/gcconnex/issues/933