### PR TITLE
System message accessibility 

### DIFF
--- a/mod/wet4/views/default/page/default.php
+++ b/mod/wet4/views/default/page/default.php
@@ -67,7 +67,11 @@ if(elgg_instanceof(elgg_get_page_owner_entity(), 'group')){
 
 $feedbackText= elgg_echo('wet:feedbackText');
 $body = <<<__BODY
+<div class="elgg-page-messages container">
+    $messages
+</div> 
     $tabskip
+
 <div class="elgg-page elgg-page-default">
 
 __BODY;
@@ -93,9 +97,7 @@ $navbar
 $breadcrumbs
 
 	</header>
-    <div class="elgg-page-messages container">
-		$messages
-	   </div>
+
        <div class="container">
        $userMenu
        </div>

--- a/mod/wet4/views/default/page/elements/messages.php
+++ b/mod/wet4/views/default/page/elements/messages.php
@@ -15,7 +15,7 @@
  */
 
  //we can change it from assertive to polite if it is well ... too assertive :3
-echo '<ul class="elgg-system-messages custom-message list-unstyled" aria-live="assertive" >';
+echo '<ul class="elgg-system-messages custom-message list-unstyled mrgn-bttm-0" aria-live="assertive" >';
 
 // hidden li so we validate
 echo '<li class="hidden wb-invisible"></li>';

--- a/mod/wet4/views/default/wet4_theme/css.php
+++ b/mod/wet4/views/default/wet4_theme/css.php
@@ -4285,7 +4285,7 @@ a.thumbnail.active {
 
 .alert {
   padding: 15px;
-  margin-bottom: 23px;
+  margin-bottom: 2px;
   border: 1px solid transparent;
   border-radius: 4px; }
   .alert h4 {

--- a/mod/wet4/views/default/wet4_theme/custom_css.php
+++ b/mod/wet4/views/default/wet4_theme/custom_css.php
@@ -1302,6 +1302,12 @@ border:none;
     position: absolute;
 }
 
+.custom-message{
+    position: fixed;
+    width: 1140px;
+    z-index: 9999;
+    top: 185px;
+}
 
 .elgg-state-success {
   background-color: #dff0d8;

--- a/mod/wet4/views/default/wet4_theme/custom_css.php
+++ b/mod/wet4/views/default/wet4_theme/custom_css.php
@@ -1310,7 +1310,7 @@ border:none;
     z-index: 100000;
 
    margin: 0 auto;
-    width: 70%;
+    width: 1140px;
     border-left: solid 5px #2b542c;
    }
   .elgg-state-success hr {
@@ -1338,7 +1338,7 @@ details.elgg-state-success:before {
     z-index: 100000;
 
    margin: 0 auto;
-    width: 70%;
+    width: 1140px;;
     border-left: solid 5px #843534;
 }
   .elgg-state-error hr {


### PR DESCRIPTION
Moved the site system messages to the top of the page. This will allow them to be read first by screen readers (specifically JAWS) when the page reloads. There is also an aria-live on the element so when ajax system messages appear they will also be read.

fixes #913 

The above issue only references the login system message but it is also an issue with all system messages.