### PR TITLE
Fix for Wire posts with URL encoding

### DIFF
--- a/mod/wet4/views/default/object/thewire.php
+++ b/mod/wet4/views/default/object/thewire.php
@@ -63,7 +63,8 @@ if (elgg_instanceof($container, "group") && ($container->getGUID() != elgg_get_p
 }
 
 // show text different in widgets
-$text = htmlspecialchars_decode($post->description, ENT_QUOTES);
+$text = urldecode(htmlspecialchars_decode($post->description, ENT_QUOTES));
+
 if (elgg_in_context("widgets")) {
 	$text = elgg_get_excerpt($text, 140);
 	


### PR DESCRIPTION
When users are sharing to the wire from another site the URL encoding appears in the text. This should remove that encoding (example %20 for space).

Fixes #790 

This issue was reopened to fix the URL encoding.