### PR TITLE
Adding like and unlike links to groups entity menu

### DIFF
--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -386,11 +386,11 @@ function groups_entity_menu_setup($hook, $type, $return, $params) {
 	/* @var ElggMenuItem $item */
 	foreach ($return as $index => $item) {
 		if ( get_group_members($entity->guid, 10, 0, 0, true) > 1 )
-			if (in_array($item->getName(), array('access', 'likes', 'unlike', 'edit'/*, 'delete'*/))) {
+			if (in_array($item->getName(), array('access', 'edit'))) {
 				unset($return[$index]);
 		}
 		if ( get_group_members($entity->guid, 10, 0, 0, true) == 1 )
-			if (in_array($item->getName(), array('access', 'likes', 'unlike', 'edit'))) {
+			if (in_array($item->getName(), array('access', 'edit'))) {
 				unset($return[$index]);
 		}
 	}


### PR DESCRIPTION
Adding a link to like and unlike a group from the group entity menu (when groups are in a list view)

Closes #552 

I modified the group mod as it's entity menu was unsetting the like/unlike links.