### PR TITLE
Build: Add Docker for Composer install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,10 @@ FROM ubuntu:14.04
 MAINTAINER Luc Belliveau <luc.belliveau@nrc-cnrc.gc.ca>
 
 # Install dependencies
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
-RUN apt-get install -y git apache2 php5 libapache2-mod-php5 php5-mysql php5-gd php5-curl
+RUN apt-get install -y git apache2 php5 libapache2-mod-php5 php5-mysql php5-gd php5-curl curl
+RUN curl -sS https://getcomposer.org/installer | sudo php -- --install-dir=/usr/local/bin --filename=composer
 
 # Enable Apache mod_rewrite
 RUN a2enmod rewrite
@@ -20,8 +22,12 @@ RUN sed -i '/ErrorLog ${APACHE_LOG_DIR}\/error.log/c\ErrorLog \/dev\/stderr' /et
 # Uncomment to also see access log (rebuild with docker-compose up --build)
 # RUN sed -i '/CustomLog ${APACHE_LOG_DIR}\/access.log combined/c\CustomLog \/dev\/stdout combined' /etc/apache2/sites-available/000-default.conf
 
+COPY . /var/www/html
 WORKDIR /var/www/html
+
+ARG COMPOSER_ALLOW_SUPERUSER=1
+ARG COMPOSER_NO_INTERACTION=1
+RUN composer install
 
 # Start Apache in foreground mode
 CMD chown www-data /data && rm -f /var/run/apache2/apache2.pid && /usr/sbin/apache2ctl -D FOREGROUND
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,8 @@ services:
     volumes:
       - .:/var/www/html
       - ./data/data:/data
+      - /var/www/html/mod
+      - /var/www/html/vendor
     depends_on:
       - gcconnex-db
       # - nginx-proxy


### PR DESCRIPTION
Realized with the removal of the previously checked in mod & vendor files, the Docker setup would be broken.
The mod and vendor folders are masked in the volume mount so they doen't get wiped out

/cc @lucbelliveau