### PR TITLE
Add group operators page will not try to load all members and will still work

### DIFF
--- a/mod/group_operators/pages/group_operators/manage.php
+++ b/mod/group_operators/pages/group_operators/manage.php
@@ -33,7 +33,7 @@ $title = sprintf(elgg_echo("group_operators:title"), $group->name);
 $content = elgg_view_group_operators_list($group);
 
 $form_vars = array();
-$body_vars = array('entity' => $group); //Removing loading of all group members / variables using group_operators_prepare_form_vars as this can cause the server to time out for very large groups, now manually adding group oubject var only
+$body_vars = array('entity' => $group); //Removing loading of all group members / variables using group_operators_prepare_form_vars as this can cause the server to time out for very large groups, now manually adding group object var only
 
 $content .= elgg_view_form('group_operators/add', $form_vars, $body_vars);
 

--- a/mod/group_operators/pages/group_operators/manage.php
+++ b/mod/group_operators/pages/group_operators/manage.php
@@ -33,7 +33,7 @@ $title = sprintf(elgg_echo("group_operators:title"), $group->name);
 $content = elgg_view_group_operators_list($group);
 
 $form_vars = array();
-$body_vars = array(); //group_operators_prepare_form_vars($group);			Removing loading of all group members as this can cause the server to time out or run out of ram trying to load them all for very large groups
+$body_vars = array('entity' => $group); //group_operators_prepare_form_vars($group);			Removing loading of all group members as this can cause the server to time out or run out of ram trying to load them all for very large groups
 
 $content .= elgg_view_form('group_operators/add', $form_vars, $body_vars);
 

--- a/mod/group_operators/pages/group_operators/manage.php
+++ b/mod/group_operators/pages/group_operators/manage.php
@@ -33,7 +33,7 @@ $title = sprintf(elgg_echo("group_operators:title"), $group->name);
 $content = elgg_view_group_operators_list($group);
 
 $form_vars = array();
-$body_vars = array('entity' => $group); //group_operators_prepare_form_vars($group);			Removing loading of all group members as this can cause the server to time out or run out of ram trying to load them all for very large groups
+$body_vars = array('entity' => $group); //Removing loading of all group members / variables using group_operators_prepare_form_vars as this can cause the server to time out for very large groups, now manually adding group oubject var only
 
 $content .= elgg_view_form('group_operators/add', $form_vars, $body_vars);
 


### PR DESCRIPTION
Only group guid is now added to global vars when preparing group operators page.
fixes #1096