### PR TITLE
quick fix to link to managers profile

### DIFF
--- a/mod/missions/views/default/page/elements/mission-manager-info.php
+++ b/mod/missions/views/default/page/elements/mission-manager-info.php
@@ -38,7 +38,7 @@ $manager_name = $mission->name;
 $manager_icon = elgg_view_entity_icon(get_entity(1), 'small');
 if($manager_account) {
 	$manager_name = elgg_view('output/url', array(
-			'href' => elgg_get_site_url().'profile/'.$manager_account->username,//$manager_account->getURL(), //Nick changed to profile url
+			'href' => elgg_get_site_url().'profile/'.$manager_account->username,
 			'text' => $manager_name,
 			'class' => 'mission-user-link-' . $mission->owner_guid
 	));

--- a/mod/missions/views/default/page/elements/mission-manager-info.php
+++ b/mod/missions/views/default/page/elements/mission-manager-info.php
@@ -38,7 +38,7 @@ $manager_name = $mission->name;
 $manager_icon = elgg_view_entity_icon(get_entity(1), 'small');
 if($manager_account) {
 	$manager_name = elgg_view('output/url', array(
-			'href' => elgg_get_site_url().'profile/'.$manager_name,//$manager_account->getURL(), //Nick changed to profile url
+			'href' => elgg_get_site_url().'profile/'.$manager_account->username,//$manager_account->getURL(), //Nick changed to profile url
 			'text' => $manager_name,
 			'class' => 'mission-user-link-' . $mission->owner_guid
 	));


### PR DESCRIPTION
On prod the url contains the managers display name and it redirects to newsfeed. Changed the url to link to the profile with username. This should now properly link to the managers profile.

Fixes #1117 