### PR TITLE
Enhanced user search

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,8 @@ FROM ubuntu:14.04
 MAINTAINER Luc Belliveau <luc.belliveau@nrc-cnrc.gc.ca>
 
 # Install dependencies
-RUN echo bla
 RUN apt-get update
-RUN apt-get install -y git apache2 php5 libapache2-mod-php5 php5-mysql php5-gd php5-curl wget
+RUN apt-get install -y git apache2 php5 libapache2-mod-php5 php5-mysql php5-gd php5-curl
 
 # Enable Apache mod_rewrite
 RUN a2enmod rewrite
@@ -12,16 +11,6 @@ RUN a2enmod rewrite
 # Modify Apache config for Elgg
 RUN echo '<Directory /var/www/html>\nOptions Indexes FollowSymLinks MultiViews\nAllowOverride All\nOrder allow,deny\nallow from all\n</Directory>\n' | sed '/^<VirtualHost \*:80>/r /dev/stdin' /etc/apache2/sites-available/000-default.conf > /etc/apache2/sites-available/tmp
 RUN mv /etc/apache2/sites-available/tmp /etc/apache2/sites-available/000-default.conf
-
-# Add a copy of GCconnex to the image
-COPY . /var/www/html
-
-# Install the Elgg crontab
-RUN cp /var/www/html/docs/examples/crontab.example /opt/crontab.example
-RUN sed -i 's/www.example.com/127\.0\.0\.1/' /opt/crontab.example
-RUN sed -i 's/lwp-request/wget/' /opt/crontab.example
-RUN sed -i 's/-m GET -d/--output-document=\/dev\/null --spider/' /opt/crontab.example
-RUN crontab /opt/crontab.example
 
 # Modify Apache config to output access and error log to stdio
 # So we can see the output using `docker-compose logs` or directly with `docker-compose up`)

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,9 @@ FROM ubuntu:14.04
 MAINTAINER Luc Belliveau <luc.belliveau@nrc-cnrc.gc.ca>
 
 # Install dependencies
+RUN echo bla
 RUN apt-get update
-RUN apt-get install -y git apache2 php5 libapache2-mod-php5 php5-mysql php5-gd php5-curl
+RUN apt-get install -y git apache2 php5 libapache2-mod-php5 php5-mysql php5-gd php5-curl wget
 
 # Enable Apache mod_rewrite
 RUN a2enmod rewrite
@@ -11,6 +12,16 @@ RUN a2enmod rewrite
 # Modify Apache config for Elgg
 RUN echo '<Directory /var/www/html>\nOptions Indexes FollowSymLinks MultiViews\nAllowOverride All\nOrder allow,deny\nallow from all\n</Directory>\n' | sed '/^<VirtualHost \*:80>/r /dev/stdin' /etc/apache2/sites-available/000-default.conf > /etc/apache2/sites-available/tmp
 RUN mv /etc/apache2/sites-available/tmp /etc/apache2/sites-available/000-default.conf
+
+# Add a copy of GCconnex to the image
+COPY . /var/www/html
+
+# Install the Elgg crontab
+RUN cp /var/www/html/docs/examples/crontab.example /opt/crontab.example
+RUN sed -i 's/www.example.com/127\.0\.0\.1/' /opt/crontab.example
+RUN sed -i 's/lwp-request/wget/' /opt/crontab.example
+RUN sed -i 's/-m GET -d/--output-document=\/dev\/null --spider/' /opt/crontab.example
+RUN crontab /opt/crontab.example
 
 # Modify Apache config to output access and error log to stdio
 # So we can see the output using `docker-compose logs` or directly with `docker-compose up`)

--- a/Dockerfile.cron
+++ b/Dockerfile.cron
@@ -1,0 +1,20 @@
+FROM ubuntu:14.04
+MAINTAINER Luc Belliveau <luc.belliveau@nrc-cnrc.gc.ca>
+
+# Install dependencies
+RUN apt-get update
+RUN apt-get install -y wget
+
+# Add a copy of crontab example to the image
+COPY ./docs/examples/crontab.example /opt/crontab.example
+
+# Install the Elgg crontab
+RUN sed -i 's/www.example.com/gcconnex/' /opt/crontab.example
+RUN sed -i 's/lwp-request/wget/' /opt/crontab.example
+RUN sed -i 's/\$LWPR -m GET -d/\/usr\/bin\/wget --output-document=\/dev\/null --spider/' /opt/crontab.example
+RUN crontab /opt/crontab.example
+
+WORKDIR /var/www/html
+
+# Start the cron daemon in the foreground
+CMD cron -f

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,11 @@ services:
     environment:
       - VIRTUAL_HOST=gcconnex.local
 
+  # ###########################################################################
+  # The GCConnex cron container.  This container is responsible for executing
+  # elgg's built in cron based on the recommended settings.
+  # ###########################################################################
+
   gcconnex-cron:
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,16 @@ services:
     environment:
       - VIRTUAL_HOST=gcconnex.local
 
+  gcconnex-cron:
+    build:
+      context: .
+      dockerfile: ./Dockerfile.cron
+    volumes:
+      - .:/var/www/html
+      - ./data/data:/data
+    depends_on:
+      - gcconnex-db
+
   # ###########################################################################
   # Database container for gcconnex, accessible from within gcconnex using the
   # network host "gcconnex-db".

--- a/mod/enhanced_user_search/lib/functions.php
+++ b/mod/enhanced_user_search/lib/functions.php
@@ -1,0 +1,172 @@
+<?php
+/**
+* Enhanced User Search
+* Copyright (c) 2017 National Research Council Canada
+* @author Luc Belliveau <luc.belliveau@nrc-cnrc.gc.ca>
+*
+* This library provides enhanced search functionality to enable rapid search
+* using the native elgg database.
+*
+* The module could also be used as an abstraction to other search providers
+* in the future such as SOLR, Elasticsearch, etc.
+*
+*/
+
+namespace NRC\EUS;
+
+require_once("sql.php");
+
+/**
+* Generic Search interface
+*/
+interface iMemberSearch {
+
+  public function initialize();
+  public function refresh();
+  public function search($term, $limit);
+
+}
+
+/**
+* Database driven implementation of the generic search interface
+*/
+class DatabaseSearch implements iMemberSearch {
+  function __construct() {
+    global $CONFIG;
+
+    $c = new SQL\Constants();
+    list(
+      $this->tableName,
+      $this->procName,
+      $this->BUILD_SQL,
+      $this->INDEX_SQL,
+      $this->REFRESH_PROC,
+      $this->SEARCH_SQL
+    ) = $c->get();
+
+    $db_config = new \Elgg\Database\Config($CONFIG);
+    $read_settings = $db_config->getConnectionConfig(
+      ($db_config->isDatabaseSplit()) ?
+        \Elgg\Database\Config::WRITE :
+        \Elgg\Database\Config::READ_WRITE
+    );
+
+    $this->db_name = $read_settings["database"];
+
+    $this->conn = mysqli_connect(
+      $read_settings["host"],
+      $read_settings["user"],
+      $read_settings["password"],
+      $read_settings["database"]
+    );
+    if (mysqli_connect_errno($this->conn))
+      elgg_log("Failed to connect: ".mysqli_connect_errno(), 'NOTICE');
+
+  }
+
+  function __destruct() {
+    mysqli_close($this->conn);
+  }
+
+  public function initialize() {
+
+    $check_query = "SELECT *
+      FROM
+        information_schema.tables
+      WHERE
+        table_schema = '{$this->db_name}'
+        AND table_name = '{$this->tableName}'
+      LIMIT 1";
+
+    $result = mysqli_query($this->conn, $check_query);
+    if ($result->num_rows === 0) {
+      mysqli_query($this->conn, $this->BUILD_SQL);
+      mysqli_query($this->conn, $this->INDEX_SQL);
+      mysqli_query($this->conn, $this->REFRESH_PROC);
+      $this->refresh();
+    }
+    mysqli_free_result($result);
+  }
+
+  public function refresh() {
+    mysqli_query($this->conn, "CALL `{$this->procName}`();");
+  }
+
+  private function isMatched($haystack, $term) {
+    $terms = split(' ', strtolower(trim($term)));
+    $h = strtolower($haystack);
+
+    foreach ($terms as $t) {
+      if (strpos($h, $t) !== false) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public function search($term, $limit=10, $offset=0) {
+    $start_time = time();
+    $p = mysqli_prepare($this->conn, $this->SEARCH_SQL);
+    $lterm = strtolower(trim($term));
+    if (strpos($lterm, '*') === strlen($lterm)-1) {
+      $lterm = substr($lterm, 0, strlen($lterm)-1);
+    }
+
+    $p->bind_param('ssii', $term, $term, $offset, $limit);
+    $p->execute();
+    $p->bind_result(
+      $user_guid,
+      $name,
+      $relevance,
+      $contactemail,
+      $education,
+      $gc_skills,
+      $portfolio,
+      $work
+    );
+
+    $users = [];
+    while ($p->fetch()) {
+
+      $users[] = array(
+        'user_guid' => $user_guid,
+        'name' => $name,
+        'relevance' => $relevance,
+        'contactemail' => $contactemail,
+        'education' => $education,
+        'gc_skills' => $gc_skills,
+        'portfolio' => $portfolio,
+        'work' => $work,
+        'matched_using' => array(
+          'name' => $this->isMatched($name, $lterm),
+          'contactemail' => $this->isMatched($contactemail, $lterm),
+          'education' => $this->isMatched($education, $lterm),
+          'gc_skills' => $this->isMatched($gc_skills, $lterm),
+          'portfolio' => $this->isMatched($portfolio, $lterm),
+          'work' => $this->isMatched($work, $lterm)
+        )
+      );
+    }
+
+    $total = mysqli_query($this->conn, 'SELECT FOUND_ROWS() as total_users');
+    $r = $total->fetch_row();
+    $total_users = $r[0];
+    mysqli_free_result($total);
+    $p->close();
+    return array(
+      'term' => $term,
+      'execution_time' => $start_time - time(),
+      'total' => $total_users,
+      'start' => $offset,
+      'rows' => count($users),
+      'users' => $users
+    );
+  }
+}
+
+function get() {
+  // we could allow configuration of backends here
+  return new DatabaseSearch();
+}
+
+

--- a/mod/enhanced_user_search/lib/functions.php
+++ b/mod/enhanced_user_search/lib/functions.php
@@ -23,7 +23,8 @@ interface iMemberSearch {
 
   public function initialize();
   public function refresh();
-  public function search($term, $limit);
+  public function search($term, $limit, $offset);
+  public function isReady();
 
 }
 
@@ -41,7 +42,8 @@ class DatabaseSearch implements iMemberSearch {
       $this->BUILD_SQL,
       $this->INDEX_SQL,
       $this->REFRESH_PROC,
-      $this->SEARCH_SQL
+      $this->SEARCH_SQL,
+      $this->READY_SQL
     ) = $c->get();
 
     $db_config = new \Elgg\Database\Config($CONFIG);
@@ -86,6 +88,13 @@ class DatabaseSearch implements iMemberSearch {
       $this->refresh();
     }
     mysqli_free_result($result);
+  }
+
+  public function isReady() {
+    $result = mysqli_query($this->conn, $this->READY_SQL);
+    $ready = $result->num_rows === 1;
+    mysqli_free_result($result);
+    return $ready;
   }
 
   public function refresh() {
@@ -167,6 +176,11 @@ class DatabaseSearch implements iMemberSearch {
 function get() {
   // we could allow configuration of backends here
   return new DatabaseSearch();
+}
+
+function ready() {
+  $s = new DatabaseSearch();
+  return $s->isReady();
 }
 
 

--- a/mod/enhanced_user_search/lib/functions.php
+++ b/mod/enhanced_user_search/lib/functions.php
@@ -142,8 +142,10 @@ class DatabaseSearch implements iMemberSearch {
   public function initialize() {
     $result = mysqli_query($this->conn, $this->TABLE_EXISTS_SQL);
     if ($result->num_rows === 0) {
-      mysqli_query($this->conn, $this->BUILD_SQL);
-      mysqli_query($this->conn, $this->INDEX_SQL);
+      mysqli_multi_query($this->conn, $this->BUILD_SQL);
+      while (mysqli_next_result($this->conn)) {;}
+      mysqli_multi_query($this->conn, $this->INDEX_SQL);
+      while (mysqli_next_result($this->conn)) {;}
     }
     mysqli_free_result($result);
 

--- a/mod/enhanced_user_search/lib/functions.php
+++ b/mod/enhanced_user_search/lib/functions.php
@@ -164,6 +164,7 @@ class DatabaseSearch implements iMemberSearch {
   }
 
   public function refresh() {
+    set_time_limit(500);
     mysqli_query($this->conn, "CALL `{$this->procName}`();");
   }
 

--- a/mod/enhanced_user_search/lib/sql.php
+++ b/mod/enhanced_user_search/lib/sql.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace NRC\EUS\SQL;
+
+class Constants {
+  public function get() {
+    $dbprefix = elgg_get_config("dbprefix");
+
+    $tableName = "NRC_EUS_mvMemberSearch";
+    $procName = "NRC_EUS_Refresh_MemberSearch";
+
+    $BUILD_SQL = "
+    CREATE TABLE IF NOT EXISTS `{$tableName}` (
+      user_guid bigint(20) unsigned not null,
+      name text not null,
+      contactemail text,
+      education text,
+      gc_skills text,
+      portfolio text,
+      work text
+    );";
+
+    $INDEX_SQL = "
+    CREATE FULLTEXT INDEX NRC_EUS_MemberSearch ON
+      {$tableName}(
+        name,
+        contactemail,
+        education,
+        gc_skills,
+        portfolio,
+        work
+      );";
+    $REFRESH_PROC = "
+    CREATE PROCEDURE `{$procName}` ()
+    BEGIN
+      TRUNCATE TABLE {$tableName};
+
+      INSERT INTO {$tableName}
+      SELECT
+        a.guid as user_guid,
+        a.name as name,
+        c.string as contactemail,
+        GROUP_CONCAT(DISTINCT f1.title SEPARATOR ', ') as education,
+        GROUP_CONCAT(DISTINCT f2.title SEPARATOR ', ') as gc_skills,
+        GROUP_CONCAT(DISTINCT f3.title SEPARATOR ', ') as portfolio,
+        GROUP_CONCAT(DISTINCT f4.title SEPARATOR ', ') as work
+      FROM
+        elggusers_entity a
+
+        LEFT JOIN {$dbprefix}metadata b ON b.entity_guid = a.guid AND b.name_id = (SELECT id from {$dbprefix}metastrings WHERE string = 'contactemail')
+        LEFT JOIN {$dbprefix}metastrings c ON c.id = b.value_id
+
+        LEFT JOIN {$dbprefix}metadata d1 ON d1.entity_guid = a.guid AND d1.name_id IN (SELECT id from {$dbprefix}metastrings WHERE string = 'education')
+        LEFT JOIN {$dbprefix}metastrings e1 ON e1.id = d1.value_id
+        LEFT JOIN {$dbprefix}objects_entity f1 ON f1.guid = e1.string
+
+        LEFT JOIN {$dbprefix}metadata d2 ON d2.entity_guid = a.guid AND d2.name_id IN (SELECT id from {$dbprefix}metastrings WHERE string = 'gc_skills')
+        LEFT JOIN {$dbprefix}metastrings e2 ON e2.id = d2.value_id
+        LEFT JOIN {$dbprefix}objects_entity f2 ON f2.guid = e2.string
+
+        LEFT JOIN {$dbprefix}metadata d3 ON d3.entity_guid = a.guid AND d3.name_id IN (SELECT id from {$dbprefix}metastrings WHERE string = 'portfolio')
+        LEFT JOIN {$dbprefix}metastrings e3 ON e3.id = d3.value_id
+        LEFT JOIN {$dbprefix}objects_entity f3 ON f3.guid = e3.string
+
+        LEFT JOIN {$dbprefix}metadata d4 ON d4.entity_guid = a.guid AND d4.name_id IN (SELECT id from {$dbprefix}metastrings WHERE string = 'work')
+        LEFT JOIN {$dbprefix}metastrings e4 ON e4.id = d4.value_id
+        LEFT JOIN {$dbprefix}objects_entity f4 ON f4.guid = e4.string
+      GROUP BY
+        a.guid;
+    END;";
+
+    $SEARCH_SQL = "
+    SELECT SQL_CALC_FOUND_ROWS
+      user_guid,
+      name,
+      MATCH(
+        name,
+        contactemail,
+        education,
+        gc_skills,
+        portfolio,
+        work
+      ) AGAINST (?) AS relevance,
+      contactemail,
+      education,
+      gc_skills,
+      portfolio,
+      work
+    FROM
+      {$tableName}
+    WHERE
+      MATCH(
+        name,
+        contactemail,
+        education,
+        gc_skills,
+        portfolio,
+        work
+      ) AGAINST (?)
+    ORDER BY
+      relevance DESC
+    LIMIT ?, ?;";
+    return array(
+      $tableName,
+      $procName,
+      $BUILD_SQL,
+      $INDEX_SQL,
+      $REFRESH_PROC,
+      $SEARCH_SQL
+    );
+  }
+}
+
+?>

--- a/mod/enhanced_user_search/lib/sql.php
+++ b/mod/enhanced_user_search/lib/sql.php
@@ -19,11 +19,29 @@ class Constants {
       gc_skills text,
       portfolio text,
       work text
+    );
+    CREATE TABLE IF NOT EXISTS `{$tableName}_tmp` (
+      user_guid bigint(20) unsigned not null,
+      name text not null,
+      contactemail text,
+      education text,
+      gc_skills text,
+      portfolio text,
+      work text
     );";
 
     $INDEX_SQL = "
     CREATE FULLTEXT INDEX NRC_EUS_MemberSearch ON
-      {$tableName}(
+      `{$tableName}`(
+        name,
+        contactemail,
+        education,
+        gc_skills,
+        portfolio,
+        work
+      );
+    CREATE FULLTEXT INDEX NRC_EUS_MemberSearchTmp ON
+      `{$tableName}_tmp`(
         name,
         contactemail,
         education,
@@ -31,12 +49,13 @@ class Constants {
         portfolio,
         work
       );";
+
     $REFRESH_PROC = "
     CREATE PROCEDURE `{$procName}` ()
     BEGIN
-      TRUNCATE TABLE {$tableName};
+      TRUNCATE TABLE `{$tableName}_tmp`;
 
-      INSERT INTO {$tableName}
+      INSERT INTO `{$tableName}_tmp`
       SELECT
         a.guid as user_guid,
         a.name as name,
@@ -68,6 +87,11 @@ class Constants {
         LEFT JOIN {$dbprefix}objects_entity f4 ON f4.guid = e4.string
       GROUP BY
         a.guid;
+
+      RENAME TABLE `{$tableName}_tmp` TO `{$tableName}_tmpA`,
+                   `{$tableName}` TO `{$tableName}_tmp`,
+                   `{$tableName}_tmpA` TO `{$tableName}`;
+
     END;";
 
     $READY_SQL = "SELECT user_guid from {$tableName} limit 1;";

--- a/mod/enhanced_user_search/lib/sql.php
+++ b/mod/enhanced_user_search/lib/sql.php
@@ -5,6 +5,7 @@ namespace NRC\EUS\SQL;
 class Constants {
   public function get() {
     $dbprefix = elgg_get_config("dbprefix");
+    $dbname = elgg_get_config("dbname");
 
     $tableName = "NRC_EUS_mvMemberSearch";
     $procName = "NRC_EUS_Refresh_MemberSearch";
@@ -102,6 +103,18 @@ class Constants {
     ORDER BY
       relevance DESC
     LIMIT ?, ?;";
+
+    $TABLE_EXISTS_SQL = "
+    SELECT *
+      FROM
+        information_schema.tables
+      WHERE
+        table_schema = '{$dbname}'
+        AND table_name = '{$tableName}'
+      LIMIT 1";
+
+    $PROC_EXISTS_SQL = "SHOW PROCEDURE STATUS WHERE name = \"${procName}\";";
+
     return array(
       $tableName,
       $procName,
@@ -109,7 +122,9 @@ class Constants {
       $INDEX_SQL,
       $REFRESH_PROC,
       $SEARCH_SQL,
-      $READY_SQL
+      $READY_SQL,
+      $TABLE_EXISTS_SQL,
+      $PROC_EXISTS_SQL
     );
   }
 }

--- a/mod/enhanced_user_search/lib/sql.php
+++ b/mod/enhanced_user_search/lib/sql.php
@@ -54,7 +54,7 @@ class Constants {
     CREATE PROCEDURE `{$procName}` ()
     BEGIN
       TRUNCATE TABLE `{$tableName}_tmp`;
-
+      SET group_concat_max_len=15000;
       INSERT INTO `{$tableName}_tmp`
       SELECT
         a.guid as user_guid,

--- a/mod/enhanced_user_search/lib/sql.php
+++ b/mod/enhanced_user_search/lib/sql.php
@@ -69,6 +69,8 @@ class Constants {
         a.guid;
     END;";
 
+    $READY_SQL = "SELECT user_guid from {$tableName} limit 1;";
+
     $SEARCH_SQL = "
     SELECT SQL_CALC_FOUND_ROWS
       user_guid,
@@ -106,7 +108,8 @@ class Constants {
       $BUILD_SQL,
       $INDEX_SQL,
       $REFRESH_PROC,
-      $SEARCH_SQL
+      $SEARCH_SQL,
+      $READY_SQL
     );
   }
 }

--- a/mod/enhanced_user_search/manifest.xml
+++ b/mod/enhanced_user_search/manifest.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin_manifest xmlns="http://www.elgg.org/plugin_manifest/1.8">
+	<name>Enhanced User Search</name>
+  <id>enhanced_user_search</id>
+	<author>Luc Belliveau</author>
+	<version>1.0</version>
+	<category>NRC</category>
+	<blurb>User Search</blurb>
+	<description>Provides enhanced search functionality</description>
+	<website>http://www.nrc-cnrc.gc.ca</website>
+	<copyright>National Research Council Canada 2017</copyright>
+	<license>GNU General Public License version 2</license>
+	<requires>
+		<type>elgg_release</type>
+		<version>1.11.3</version>
+	</requires>
+	<requires>
+		<type>plugin</type>
+		<name>missions</name>
+	</requires>
+	<requires>
+		<type>priority</type>
+		<priority>after</priority>
+		<plugin>missions</plugin>
+	</requires>
+</plugin_manifest>

--- a/mod/enhanced_user_search/manifest.xml
+++ b/mod/enhanced_user_search/manifest.xml
@@ -6,7 +6,9 @@
 	<version>1.0</version>
 	<category>NRC</category>
 	<blurb>User Search</blurb>
-	<description>Provides enhanced search functionality</description>
+	<description>
+    Provides enhanced search functionality for GCconnex
+  </description>
 	<website>http://www.nrc-cnrc.gc.ca</website>
 	<copyright>National Research Council Canada 2017</copyright>
 	<license>GNU General Public License version 2</license>

--- a/mod/enhanced_user_search/start.php
+++ b/mod/enhanced_user_search/start.php
@@ -26,7 +26,7 @@ function enhanced_user_search_init() {
 
   // Register the cron handler
   elgg_register_plugin_hook_handler(
-    'cron', 'fifteenmin', 'enhanced_user_search_cron', 1
+    'cron', 'minute', 'enhanced_user_search_cron', 1
   );
 
 }

--- a/mod/enhanced_user_search/start.php
+++ b/mod/enhanced_user_search/start.php
@@ -1,23 +1,41 @@
 <?php
+/**
+ * Entry point for the enhanced_user_search plugin.
+ *
+ */
 
+// Register the function to be called during system initialization.
 elgg_register_event_handler('init', 'system', 'enhanced_user_search_init');
 
+/**
+ * Initialize the enhanced_user_search plugin
+ *
+ * @return void
+ */
 function enhanced_user_search_init() {
+  // Register the plugin as a library available to the entire site.
 	 elgg_register_library(
      'enhanced_user_search',
      elgg_get_plugins_path() . 'enhanced_user_search/lib/functions.php'
    );
 	 elgg_load_library('enhanced_user_search');
 
+  // Initialize the plugin.
   $search = \NRC\EUS\get();
   $search->initialize();
 
+  // Register the cron handler
   elgg_register_plugin_hook_handler(
     'cron', 'fifteenmin', 'enhanced_user_search_cron', 1
   );
 
 }
 
+/**
+ * Method called by cron to refresh the search index
+ *
+ * @return void
+ */
 function enhanced_user_search_cron() {
   $search = \NRC\EUS\get();
   $search->refresh();

--- a/mod/enhanced_user_search/start.php
+++ b/mod/enhanced_user_search/start.php
@@ -26,7 +26,7 @@ function enhanced_user_search_init() {
 
   // Register the cron handler
   elgg_register_plugin_hook_handler(
-    'cron', 'minute', 'enhanced_user_search_cron', 1
+    'cron', 'halfhour', 'enhanced_user_search_cron', 1
   );
 
 }

--- a/mod/enhanced_user_search/start.php
+++ b/mod/enhanced_user_search/start.php
@@ -1,0 +1,25 @@
+<?php
+
+elgg_register_event_handler('init', 'system', 'enhanced_user_search_init');
+
+function enhanced_user_search_init() {
+	 elgg_register_library(
+     'enhanced_user_search',
+     elgg_get_plugins_path() . 'enhanced_user_search/lib/functions.php'
+   );
+	 elgg_load_library('enhanced_user_search');
+
+  $search = \NRC\EUS\get();
+  $search->initialize();
+
+  elgg_register_plugin_hook_handler(
+    'cron', 'fifteenmin', 'enhanced_user_search_cron', 1
+  );
+
+}
+
+function enhanced_user_search_cron() {
+  $search = \NRC\EUS\get();
+  $search->refresh();
+}
+


### PR DESCRIPTION
Fixes gctools-outilsgc/gcconnex#495 

# What it does
This creates the discussed materialized view to speed up search operations.  It is isolated by introducing a new plugin.

# How to test
1. Enable the plugin
2. Wait half an hour or so, or visit http://siteurl/cron/halfhour/ to trigger the update immediately.
3. Perform a search

## Notes

The search index is currently set to update every half hour - this requires that Elgg's [cron feature](http://learn.elgg.org/en/2.0/admin/cron.html) is properly configured on the server.  (I noticed the example crontab file is erroneous and wouldn't work without modification - specifically crontab does not support variable expansion during variable assignments... )

It would be good to monitor the time it takes for the update to occur, you can generate the index manually by executing the following from mysql:

```sql
CALL NRC_EUS_Refresh_MemberSearch();
```

On my system the updates takes about 20 seconds.  During this time there is no service impact, so it is safe to run.  Also until the first refresh is completed, the search will fallback to the current method - so there is no service interruption at all.

It is also safe to turn the plugin off after it's been enabled - the search will fallback to the current implementation if the plugin is not enabled.

