### PR TITLE
Make paragraph margins like most Web platforms (usually 1em or 16px)

### DIFF
--- a/mod/ckeditor/views/default/css/elgg/wysiwyg.css
+++ b/mod/ckeditor/views/default/css/elgg/wysiwyg.css
@@ -3,7 +3,6 @@
 /* The Elgg CSS reset forces the scrollbar which we don't want */
 html, body {
 	height: auto;
-	margin: 0;
 }
 
 body {

--- a/mod/wet4/views/default/wet4_theme/css.php
+++ b/mod/wet4/views/default/wet4_theme/css.php
@@ -1083,9 +1083,6 @@ h5, .h5 {
 h6, .h6 {
   font-size: 14px; }
 
-p {
-  margin: 0 0 11.5px; }
-
 .lead {
   margin-bottom: 23px;
   font-size: 18px;

--- a/mod/wet4/views/default/wet4_theme/custom_css.php
+++ b/mod/wet4/views/default/wet4_theme/custom_css.php
@@ -806,11 +806,6 @@ max-height: 500px;
 
     /****************************************/
 
-    p {
-            margin: 0 0 5.5px;
-
-    }
-
     .ideaPoints {
         font-size: 1.25em;
     }


### PR DESCRIPTION
Hi! I propose to make GCconnex paragraph margins like most Web platforms.

Current situation:
- View: 5.5px
- Edit: 0px
As this is inconsistent, users will often add blank line to add spacing between their paragraphs (because of 0px) but then, it appears with additional spacing when they view it (5.5px)

After this change:
- View and Edit: 16px (standard to most platforms)

Basic testing done in Web inspector. More required before production of course.