### PR TITLE
use extra unique entity column to prevent duplicate objects - attempt 1 (weaker constraint)

### DIFF
--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1662,13 +1662,24 @@ abstract class ElggEntity extends \ElggData implements
 				return false;
 			}
 		}
-		
-		$result = $this->getDatabase()->insertData("INSERT into {$CONFIG->dbprefix}entities
-			(type, subtype, owner_guid, site_guid, container_guid,
-				access_id, time_created, time_updated, last_action)
-			values
-			('$type', $subtype_id, $owner_guid, $site_guid, $container_guid,
-				$access_id, $time_created, $now, $now)");
+
+		if ( $type == "object" && $subtype != "widget" ){
+			$duplicate_check = md5( sanitize_string($this->title).sanitize_string($this->description) ) . $owner_guid . $time_created;
+			$result = $this->getDatabase()->insertData("INSERT into {$CONFIG->dbprefix}entities
+				(type, subtype, owner_guid, site_guid, container_guid,
+					access_id, time_created, time_updated, last_action, duplicate_check)
+				values
+				('$type', $subtype_id, $owner_guid, $site_guid, $container_guid,
+					$access_id, $time_created, $now, $now, '$duplicate_check')");
+		}
+		else {
+			$result = $this->getDatabase()->insertData("INSERT into {$CONFIG->dbprefix}entities
+				(type, subtype, owner_guid, site_guid, container_guid,
+					access_id, time_created, time_updated, last_action)
+				values
+				('$type', $subtype_id, $owner_guid, $site_guid, $container_guid,
+					$access_id, $time_created, $now, $now)");
+		}
 
 		if (!$result) {
 			throw new \IOException("Unable to save new object's base entity information!");

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1671,7 +1671,7 @@ abstract class ElggEntity extends \ElggData implements
 						access_id, time_created, time_updated, last_action, enabled, duplicate_check)
 					values
 					('$type', $subtype_id, $owner_guid, $site_guid, $container_guid,
-						$access_id, $time_created, $now, $now, 0, '$duplicate_check')");
+						$access_id, $time_created, $now, $now, 'no', '$duplicate_check')");
 			}
 			catch( DatabaseException $e ){
 				error_log("Duplication prevented: " . $e->getMessage());

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1665,12 +1665,18 @@ abstract class ElggEntity extends \ElggData implements
 
 		if ( $type == "object" && $subtype != "widget" ){
 			$duplicate_check = md5( sanitize_string($this->title).sanitize_string($this->description) ) . $owner_guid . $time_created;
-			$result = $this->getDatabase()->insertData("INSERT into {$CONFIG->dbprefix}entities
-				(type, subtype, owner_guid, site_guid, container_guid,
-					access_id, time_created, time_updated, last_action, duplicate_check)
-				values
-				('$type', $subtype_id, $owner_guid, $site_guid, $container_guid,
-					$access_id, $time_created, $now, $now, '$duplicate_check')");
+			try{
+				$result = $this->getDatabase()->insertData("INSERT into {$CONFIG->dbprefix}entities
+					(type, subtype, owner_guid, site_guid, container_guid,
+						access_id, time_created, time_updated, last_action, enabled, duplicate_check)
+					values
+					('$type', $subtype_id, $owner_guid, $site_guid, $container_guid,
+						$access_id, $time_created, $now, $now, 0, '$duplicate_check')");
+			}
+			catch( DatabaseException $e ){
+				error_log("Duplication prevented: " . $e->getMessage());
+				return null;
+			}
 		}
 		else {
 			$result = $this->getDatabase()->insertData("INSERT into {$CONFIG->dbprefix}entities

--- a/engine/classes/ElggEntity.php
+++ b/engine/classes/ElggEntity.php
@@ -1663,19 +1663,29 @@ abstract class ElggEntity extends \ElggData implements
 			}
 		}
 
-		if ( $type == "object" && $subtype != "widget" ){
-			$duplicate_check = md5( sanitize_string($this->title).sanitize_string($this->description) ) . $owner_guid . $time_created;
-			try{
-				$result = $this->getDatabase()->insertData("INSERT into {$CONFIG->dbprefix}entities
-					(type, subtype, owner_guid, site_guid, container_guid,
-						access_id, time_created, time_updated, last_action, enabled, duplicate_check)
-					values
-					('$type', $subtype_id, $owner_guid, $site_guid, $container_guid,
-						$access_id, $time_created, $now, $now, 'no', '$duplicate_check')");
+		if ( $type == "object" ){
+			if ( $subtype == "mission-posted" || $subtype == "mission" ){
+				$duplicate_check = md5( sanitize_string($this->title).sanitize_string($this->description) ) . $owner_guid . $time_created;
+				try{
+					$result = $this->getDatabase()->insertData("INSERT into {$CONFIG->dbprefix}entities
+						(type, subtype, owner_guid, site_guid, container_guid,
+							access_id, time_created, time_updated, last_action, enabled, duplicate_check)
+						values
+						('$type', $subtype_id, $owner_guid, $site_guid, $container_guid,
+							$access_id, $time_created, $now, $now, 'no', '$duplicate_check')");
+				}
+				catch( DatabaseException $e ){
+					error_log("Duplication prevented: " . $e->getMessage());
+					return null;
+				}
 			}
-			catch( DatabaseException $e ){
-				error_log("Duplication prevented: " . $e->getMessage());
-				return null;
+			else{
+				$result = $this->getDatabase()->insertData("INSERT into {$CONFIG->dbprefix}entities
+						(type, subtype, owner_guid, site_guid, container_guid,
+							access_id, time_created, time_updated, last_action, enabled)
+						values
+						('$type', $subtype_id, $owner_guid, $site_guid, $container_guid,
+							$access_id, $time_created, $now, $now, 'no')");
 			}
 		}
 		else {

--- a/engine/classes/ElggObject.php
+++ b/engine/classes/ElggObject.php
@@ -146,7 +146,8 @@ class ElggObject extends \ElggEntity {
 			// TODO(evan): Throw an exception here?
 			return false;
 		}
-		
+
+		$this->enable();
 		return $guid;
 	}
 


### PR DESCRIPTION
Prevents duplicate objects through the use of a unique column based on title,discription, and ownerGUID and timestamp

Duplicate objects that are submitted at different times to the server will not be filtered out with this, if we get any more after this is implemented I can add stronger constraints.

requires adding extra column to the entities table:
```` sql
ALTER TABLE {prefix}entities ADD COLUMN `duplicate_check` char(100) UNIQUE NULL 
````
This way older entries will remain null and anything that's not an object will be unaffected, but duplicates will be prevented from being added to the database on the fist step.

If this works, I'll add this column to the install scripts.