### PR TITLE
Search to add a subgroup + group operator title+ welcome message

### DIFF
--- a/mod/au_subgroups/views/default/au_subgroups/search_results.php
+++ b/mod/au_subgroups/views/default/au_subgroups/search_results.php
@@ -24,7 +24,7 @@ if (empty($vars['q'])) {
 }
 else {
   $query = sanitize_string($vars['q']);
-  $options['wheres'][] = "g.name LIKE '{$query}%'";
+  $options['wheres'][] = "g.name LIKE '%{$query}%'";
 }
 
 $groups = elgg_get_entities($options);

--- a/mod/gc_group_layout/views/default/group_tools/forms/welcome_message.php
+++ b/mod/gc_group_layout/views/default/group_tools/forms/welcome_message.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Group Tools
+ *
+ * Configure a welcome message to send to a new member when he/she joins the group
+ *
+ * @author ColdTrick IT Solutions
+ * 
+ */
+
+$group = elgg_extract("entity", $vars);
+$lang = get_current_language();
+if (!empty($group) && ($group instanceof ElggGroup) && $group->canEdit()) {
+	$title = elgg_echo("group_tools:welcome_message:title");
+	
+	$form_body = "<div>" . elgg_echo("group_tools:welcome_message:description") . "</div>";
+	$form_body .= elgg_view("input/longtext", array("name" => "welcome_message", "value" => $group->getPrivateSetting("group_tools:welcome_message")));
+	
+	$form_body .= "<div class='elgg-subtext'>";
+	$form_body .= elgg_view("output/longtext", array("value" => elgg_echo("group_tools:welcome_message:explain", array(
+		elgg_get_logged_in_user_entity()->name,
+		gc_explode_translation($group->name,$lang),
+		$group->getURL()
+	))));
+	$form_body .= "</div>";
+	
+	$form_body .= "<div class='elgg-footer'>";
+	$form_body .= elgg_view("input/hidden", array("name" => "group_guid", "value" => $group->getGUID()));
+	$form_body .= elgg_view("input/submit", array("value" => elgg_echo("save")));
+	
+	$content = elgg_view("input/form", array("action" => "action/group_tools/welcome_message", "body" => $form_body));
+	
+	echo elgg_view_module("info", $title, $content);
+}

--- a/mod/group_operators/pages/group_operators/manage.php
+++ b/mod/group_operators/pages/group_operators/manage.php
@@ -9,7 +9,7 @@
  */
 
 elgg_load_library('elgg:group_operators');
-
+$lang = get_current_language();
 $group_guid = (int) get_input('group_guid');
 $group = new ElggGroup($group_guid);
 if (!$group) {
@@ -25,10 +25,10 @@ elgg_set_page_owner_guid($group->guid);
 elgg_set_context('groups');
 
 elgg_push_breadcrumb(elgg_echo('group'), "groups/all");
-elgg_push_breadcrumb($group->name, $group->getURL());
+elgg_push_breadcrumb(gc_explode_translation($group->name,$lang), $group->getURL());
 elgg_push_breadcrumb(elgg_echo("group_operators:operators"));
 
-$title = sprintf(elgg_echo("group_operators:title"), $group->name);
+$title = sprintf(elgg_echo("group_operators:title"), gc_explode_translation($group->name,$lang));
 
 $content = elgg_view_group_operators_list($group);
 


### PR DESCRIPTION
Few language fix.

The search for a group to make it a subgroup now search in all the string and not the start of the string.
Title of the group operators page is fix.
Fix issue #1223 
The name of the group in the exemple of the group welcome message is fix.

