### PR TITLE
chore: use NodeJS 6 on Travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: php
 php:
  - 5.6
 
+node_js:
+ - 6
+
 # This helps builds go quicker on Travis since it enables caching of dependencies
 # http://docs.travis-ci.com/user/workers/container-based-infrastructure/
 sudo: false


### PR DESCRIPTION
The recent build image updates seems to have cause issues with some of the old node_dependencies
https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming
/cc @pandurx 