### PR TITLE
fixed docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Luc Belliveau <luc.belliveau@nrc-cnrc.gc.ca>
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
 RUN apt-get install -y git apache2 php5 libapache2-mod-php5 php5-mysql php5-gd php5-curl curl
-RUN curl -sS https://getcomposer.org/installer | sudo php -- --install-dir=/usr/local/bin --filename=composer
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 # Enable Apache mod_rewrite
 RUN a2enmod rewrite

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ ARG COMPOSER_NO_INTERACTION=1
 RUN composer install
 
 # Start Apache in foreground mode
-CMD chown www-data /data && rm -f /var/run/apache2/apache2.pid && /usr/sbin/apache2ctl -D FOREGROUND
+CMD chown www-data /var/www/html/data && chown www-data /var/www/html/engine && rm -f /var/run/apache2/apache2.pid && /usr/sbin/apache2ctl -D FOREGROUND

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - 8080:80
     volumes:
       - .:/var/www/html
-      - ./data/data:/data
+      - ./data/data:/var/www/html/data
       - /var/www/html/vendor
     depends_on:
       - gcconnex-db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,6 @@ services:
     volumes:
       - .:/var/www/html
       - ./data/data:/data
-      - /var/www/html/mod
       - /var/www/html/vendor
     depends_on:
       - gcconnex-db
@@ -42,15 +41,15 @@ services:
   # elgg's built in cron based on the recommended settings.
   # ###########################################################################
 
-  gcconnex-cron:
-    build:
-      context: .
-      dockerfile: ./Dockerfile.cron
-    volumes:
-      - .:/var/www/html
-      - ./data/data:/data
-    depends_on:
-      - gcconnex-db
+#  gcconnex-cron:
+#    build:
+#      context: .
+#      dockerfile: ./Dockerfile.cron
+#    volumes:
+#      - .:/var/www/html
+#      - ./data/data:/data
+#    depends_on:
+#      - gcconnex-db
 
   # ###########################################################################
   # Database container for gcconnex, accessible from within gcconnex using the


### PR DESCRIPTION
* No sudo for compose install in container
* cron can't build with the docs removed, removed from docker-compose for
 now
* put /mod directory back as a mapped volume since that's where most development
 happens
* added a chown command (/engine) to make sure the installer doesn't have any problems
* fixed for regular docker run image too (it couldn't find /data directory)