### PR TITLE
(fix) gc_explode_translation() in core

### DIFF
--- a/engine/lib/views.php
+++ b/engine/lib/views.php
@@ -485,10 +485,12 @@ function _elgg_views_prepare_head($title) {
 
 	if (empty($title)) {
 		$params['title'] = elgg_get_config('sitename');
-	} else {
+	} else if ( elgg_is_active_plugin('wet4') ) {
 		//add translation
 		$params['title'] = gc_explode_translation($title,get_current_language()) . ' : ' . elgg_get_config('sitename');
-		
+	}else {
+		//add translation
+		$params['title'] = $title . ' : ' . elgg_get_config('sitename');
 	}
 
 	$params['metas']['content-type'] = array(


### PR DESCRIPTION
gc_explode_translation() will only be called if the wet4 mod is active.
fixes #1251 