### PR TITLE
No notifications being sent out issue

### DIFF
--- a/mod/blog_tools/actions/blog/save.php
+++ b/mod/blog_tools/actions/blog/save.php
@@ -70,7 +70,7 @@ $values = array(
 );
 
 // fail if a required entity isn't set
-//$required = array('title', 'description');
+$required = array('title', 'description');
 $cart = array(); //Create a array to compare if english or french title and description is in.
 foreach ($values as $name => $default) {
 

--- a/mod/blog_tools/actions/blog/save.php
+++ b/mod/blog_tools/actions/blog/save.php
@@ -250,6 +250,7 @@ if (!$error) {
 			// we only want notifications sent when post published
 			elgg_trigger_event('publish', 'object', $blog);
 			
+
 			// reset the creation time for posts that move from draft to published
 			if ($guid) {
 				$blog->time_created = time();

--- a/mod/cp_notifications/languages/en.php
+++ b/mod/cp_notifications/languages/en.php
@@ -6,6 +6,8 @@ $contact_us = "{$site->getURL()}mod/contactform/?utm_source=notification_digest&
 
 $english = array(
 
+	'notifications:did_not_send' => "Notifications did not send",
+
 	'minor_save:title' => "Don’t want to send a notification?",
 	'minor_save:description' => "Posting new content will send out notifications to those who are subscribed. As the group owner or operator, you can decide not to send out notifications about the new content you post in the group. To do so, select the option “Do not send a notification” below.",
 	'minor_save:checkbox_label' => " Do not send a notification",
@@ -259,6 +261,10 @@ $english = array(
 
 
 	// likes section
+	'cp_notify:subject:likes_group' => "%s liked your group '%s'",
+	'cp_notify:body_likes_group:title' => "%s liked your group '%s'",
+	'cp_notify:body_likes_group:description' => "View your group: %s",
+
 	'cp_notify:subject:likes' => "%s liked your post '%s'",
 	'cp_notify:body_likes:title' => "%s liked your post '%s'",
 

--- a/mod/cp_notifications/languages/fr.php
+++ b/mod/cp_notifications/languages/fr.php
@@ -5,11 +5,12 @@ $site_name = $site->name;
 $contact_us = "{$site->getURL()}mod/contactform/";
 
 $french = array( 
+
+	'notifications:did_not_send' => "Les notifications n'ont pas envoyé",
+
 	'minor_save:title' => "Vous ne voulez pas envoyer de notification?",
 	'minor_save:description' => "L'affichage de nouveaux contenus envoie des notifications à ceux qui sont abonné. En tant que propriétaire ou opérateur du groupe, vous pouvez décider de ne pas envoyer de notifications pour le nouveau contenu que vous affichez dans le groupe. Pour ce faire, sélectionnez l'option « Ne pas envoyer de notification » ci-dessous.",
 	'minor_save:checkbox_label' => " Ne pas envoyer de notification",
-
-
 
 	'cp_notifications:name' => "Paramètres de notifications",
 	'cp_notification:save:success' => "Les paramètres ont été enregistrés avec succès",
@@ -263,6 +264,11 @@ $french = array(
 
 
 	// likes section
+
+	'cp_notify:subject:likes_group' => "%s a aimé votre groupe '%s'",
+	'cp_notify:body_likes_group:title' => "%s a aimé votre groupe '%s'",
+	'cp_notify:body_likes_group:description' => "Voir votre groupe: %s",
+
 	'cp_notify:subject:likes' => "%s a aimé votre publication '%s'",
 	'cp_notify:body_likes:title' => "%s a aimé votre publication '%s'",
 

--- a/mod/cp_notifications/start.php
+++ b/mod/cp_notifications/start.php
@@ -527,7 +527,7 @@ function cp_overwrite_notification_hook($hook, $type, $value, $params) {
 		}
 	}
 
-		// register the error, if either of the arrays are not populated
+	// register the error, if either of the arrays are not populated
 	if (!is_array($to_recipients)) {
 		notification_logging('error: in cp_create_notification(), $to_recipients is not array');
 	}
@@ -1283,7 +1283,7 @@ function cp_create_notification($event, $type, $object) {
 
 
 
-    $notification_error_type = "";
+	$notification_error_type = "";
 
 	// check for empty subjects or empty content
 	if (empty($subject)) return false;

--- a/mod/cp_notifications/start.php
+++ b/mod/cp_notifications/start.php
@@ -1290,7 +1290,7 @@ function cp_create_notification($event, $type, $object) {
 	} // end of switch statement
 
 
-$to_recipients_site = null;
+
     $notification_error_type = "";
 
 	// check for empty subjects or empty content

--- a/mod/cp_notifications/start.php
+++ b/mod/cp_notifications/start.php
@@ -525,14 +525,11 @@ function cp_overwrite_notification_hook($hook, $type, $value, $params) {
 
 			messages_send($subject, $site_template, $to_recipient->guid, $sender_guid, 0, true, $add_to_sent);
 		}
-	} else {
-		$notification_error_type = elgg_echo('cp_notifications:chkbox:email');
 	}
 
 		// register the error, if either of the arrays are not populated
 	if (!is_array($to_recipients)) {
 		notification_logging('error: in cp_create_notification(), $to_recipients is not array');
-		system_message(elgg_echo('notifications:did_not_send')." ({$notification_error_type})");
 	}
 }
 
@@ -896,8 +893,6 @@ function cp_create_annotation_notification($event, $type, $object) {
 				}
 			}
 		}
-	} else {
-		$notification_error_type = elgg_echo('cp_notifications:chkbox:email');
 	}
 
 	if (is_array($to_recipients_site)) {
@@ -913,14 +908,11 @@ function cp_create_annotation_notification($event, $type, $object) {
 				}
 			}
 		}
-	} else {
-		$notification_error_type = ($notification_error_type === '') ? elgg_echo('cp_notifications:chkbox:site') : ' & ' . elgg_echo('cp_notifications:chkbox:site');
 	}
 
 	// register the error, if either of the arrays are not populated
 	if (!is_array($to_recipients) || !is_array($to_recipients_site)) {
 		notification_logging('error: in cp_create_notification(), $to_recipients or $to_recipients_site is not array');
-		system_message(elgg_echo('notifications:did_not_send')." ({$notification_error_type})".$content->subtype);
 	}
 
 } // end of function
@@ -1324,9 +1316,7 @@ function cp_create_notification($event, $type, $object) {
 				}
 			}
 		}
-	} else 
-		$notification_error_type = elgg_echo('cp_notifications:chkbox:email');
-
+	}
 
 	/// send site notifications
 	if (is_array($to_recipients_site)) {
@@ -1344,16 +1334,12 @@ function cp_create_notification($event, $type, $object) {
 				$site_template = elgg_view('cp_notifications/site_template', $message);
 				messages_send($subject, $site_template, $to_recipient->guid, $site->guid, 0, true, false);
 			}
-
 		}
-	} else {
-		$notification_error_type = ($notification_error_type === '') ? elgg_echo('cp_notifications:chkbox:site') : ' & ' . elgg_echo('cp_notifications:chkbox:site');
 	}
 
 	// register the error, if either of the arrays are not populated
 	if (!is_array($to_recipients) || !is_array($to_recipients_site)) {
 		notification_logging('error: in cp_create_notification(), $to_recipients or $to_recipients_site is not array');
-		system_message(elgg_echo('notifications:did_not_send')." ({$notification_error_type})");
 	}
 
 }

--- a/mod/cp_notifications/start.php
+++ b/mod/cp_notifications/start.php
@@ -121,7 +121,6 @@ function cp_notifications_init() {
 
 function publish_blog_post_handler($event, $type, $object) {
 
-	error_log(">>>>>>>>>>>>> publishing blog post handler .... ... . . .. . {$object->getSubtype()}");
 	elgg_trigger_event('create', 'object', $object);
 }
 
@@ -162,7 +161,7 @@ function minor_save_hook_handler($hook, $type, $value, $params) {
  * @param mixed  $params  Data passed from the trigger
  */
 function cp_overwrite_notification_hook($hook, $type, $value, $params) {
-error_log(">>>>>>   overwriting notification hook    {$params['cp_msg_type']}");
+
 	elgg_load_library('elgg:gc_notification:functions');
 	$cp_msg_type = trim($params['cp_msg_type']);
 	$to_recipients = array();
@@ -627,8 +626,6 @@ function cp_create_annotation_notification($event, $type, $object) {
 	$action_type = "content_revision";
 	$author = $liked_by;
 
-error_log("annotation >>>>>    {$object->getSubtype()}");
-
 	/// EDITS TO BLOGS AND PAGES, THEY ARE CONSIDERED ANNOTATION DUE TO REVISIONS AND MULTIPLE COPIES OF SAME CONTENT
 	if (strcmp($object_subtype,'likes') != 0) {
 
@@ -872,10 +869,6 @@ error_log("annotation >>>>>    {$object->getSubtype()}");
 	}
 
 	$subject = htmlspecialchars_decode($subject,ENT_QUOTES);
-error_log('************* '.print_r($to_recipients, true));
-
-error_log('_____________  '.print_r($to_recipients_site, true));
-
 
 	if (is_array($to_recipients)) {
 		// send notification out via email
@@ -921,7 +914,7 @@ error_log('_____________  '.print_r($to_recipients_site, true));
 			}
 		}
 	} else {
-		$notification_error_type .= ' & '.elgg_echo('cp_notifications:chkbox:site');
+		$notification_error_type = ($notification_error_type === '') ? elgg_echo('cp_notifications:chkbox:site') : ' & ' . elgg_echo('cp_notifications:chkbox:site');
 	}
 
 	// register the error, if either of the arrays are not populated
@@ -943,7 +936,7 @@ error_log('_____________  '.print_r($to_recipients_site, true));
  * @param mixed $object		the object/entity of the event
  */
 function cp_create_notification($event, $type, $object) {
-error_log("create notification >>>>>>>>   {$object->getGUID()} /// {$object->getSubtype()} /// {$object->status}");
+
 	$do_not_subscribe_list = array('mission-posted', 'file', 'tidypics_batch', 'hjforum', 'hjforumcategory','hjforumtopic', 'messages', 'hjforumpost', 'site_notification', 'poll_choice','blog_revision','widget','folder','c_photo', 'cp_digest','MySkill', 'education', 'experience', 'poll_choice3');
 
 	// since we implemented the multi file upload, each file uploaded will invoke this hook once to many times (we don't allow subtype file to go through, but check the event)
@@ -1186,7 +1179,7 @@ error_log("create notification >>>>>>>>   {$object->getGUID()} /// {$object->get
 		case 'single_file_upload':
 
 		default:
-error_log(" blog >>>>>    {$object->status}");
+
 			// cyu - there is an issue with regards to auto-saving drafts
 			if (strcmp($object->getSubtype(),'blog') == 0) {
 				if (strcmp($object->status,'draft') == 0 || strcmp($object->status,'unsaved_draft') == 0) return;
@@ -1297,7 +1290,7 @@ error_log(" blog >>>>>    {$object->status}");
 	} // end of switch statement
 
 
-
+$to_recipients_site = null;
     $notification_error_type = "";
 
 	// check for empty subjects or empty content
@@ -1353,8 +1346,9 @@ error_log(" blog >>>>>    {$object->status}");
 			}
 
 		}
-	} else 
-		$notification_error_type .= '& '.elgg_echo('cp_notifications:chkbox:site');
+	} else {
+		$notification_error_type = ($notification_error_type === '') ? elgg_echo('cp_notifications:chkbox:site') : ' & ' . elgg_echo('cp_notifications:chkbox:site');
+	}
 
 	// register the error, if either of the arrays are not populated
 	if (!is_array($to_recipients) || !is_array($to_recipients_site)) {

--- a/mod/cp_notifications/views/default/cp_notifications/email_template.php
+++ b/mod/cp_notifications/views/default/cp_notifications/email_template.php
@@ -116,11 +116,17 @@ switch ($msg_type) {
 	case 'cp_likes_type': // likes
 
 		if ($vars['cp_subtype'] === 'thewire') {
-			$cp_notify_msg_title_en = elgg_echo('cp_notify:body_likes_wire:title',array($vars['cp_liked_by'],$vars['cp_description']),'en');
-			$cp_notify_msg_title_fr = elgg_echo('cp_notify:body_likes_wire:title',array($vars['cp_liked_by'],$vars['cp_description']),'fr');
+			$content_title_en = gc_explode_translation($vars['cp_description'], 'en');
+			$content_title_fr = gc_explode_translation($vars['cp_description'], 'fr');
+
+			$cp_notify_msg_title_en = elgg_echo('cp_notify:body_likes_wire:title',array($vars['cp_liked_by'], $content_title_en),'en');
+			$cp_notify_msg_title_fr = elgg_echo('cp_notify:body_likes_wire:title',array($vars['cp_liked_by'], $content_title_fr),'fr');
 		} else {
-			$cp_notify_msg_title_en = elgg_echo('cp_notify:body_likes:title',array($vars['cp_liked_by'],$vars['cp_comment_from']),'en');
-			$cp_notify_msg_title_fr = elgg_echo('cp_notify:body_likes:title',array($vars['cp_liked_by'],$vars['cp_comment_from']),'fr');
+			$content_title_en = gc_explode_translation($vars['cp_comment_from'], 'en');
+			$content_title_fr = gc_explode_translation($vars['cp_comment_from'], 'fr');
+
+			$cp_notify_msg_title_en = elgg_echo('cp_notify:body_likes:title',array($vars['cp_liked_by'], $content_title_en),'en');
+			$cp_notify_msg_title_fr = elgg_echo('cp_notify:body_likes:title',array($vars['cp_liked_by'], $content_title_fr),'fr');
 		}
 
 		$cp_notify_msg_description_en = elgg_echo('cp_notify:body_likes:description',array($vars['cp_content_url'].'?utm_source=notification&utm_medium=email'),'en');
@@ -347,10 +353,10 @@ switch ($msg_type) {
 
 
 		$cp_topic_description_en = $cp_topic_description;
-		$cp_topic_description_fr = $cp_topic_description2;
+		$cp_topic_description_fr = $cp_topic_description;
 
 		$cp_topic_description_discussion_en = gc_explode_translation($cp_topic_description_discussion,'en');
-		$cp_topic_description_discussion_fr = gc_explode_translation($cp_topic_description_discussion2,'fr');
+		$cp_topic_description_discussion_fr = gc_explode_translation($cp_topic_description_discussion,'fr');
 
 		if (strlen($cp_topic_description) > 200) {
 			$cp_topic_description = substr($cp_topic_description, 0, 200);
@@ -483,24 +489,45 @@ switch ($msg_type) {
 		$cp_notify_msg_description_fr = elgg_echo('cp_notify:body_validate_user:description',array($vars['cp_validate_user']['email'],$vars['cp_validate_url'].'&utm_source=notification&utm_medium=email'),'fr');
 		break;
 
+	case 'cp_like_group': // like a group
+		$group_name_en = gc_explode_translation($vars['cp_group'], 'en');
+		$group_name_fr = gc_explode_translation($vars['cp_group'], 'fr');
+
+		$cp_notify_msg_title_en = elgg_echo('cp_notify:body_likes_group:title', array($vars['cp_liked_by'], $group_name_en), 'en');
+		$cp_notify_msg_title_fr = elgg_echo('cp_notify:body_likes_group:title', array($vars['cp_liked_by'], $group_name_fr), 'fr');
+
+		$group_text_en = "<a href='{$vars['cp_group_link']}?utm_source=notification&utm_medium=email'>{$group_name_en}</a>";
+		$group_text_fr = "<a href='{$vars['cp_group_link']}?utm_source=notification&utm_medium=email'>{$group_name_fr}</a>";
+
+		$cp_notify_msg_description_en = elgg_echo('cp_notify:body_likes_group:description', array($group_text_en), 'en');
+		$cp_notify_msg_description_fr = elgg_echo('cp_notify:body_likes_group:description', array($group_text_fr), 'fr');
+		break;
+
 
 	case 'cp_likes_comments':
-		$cp_notify_msg_title_en = elgg_echo('cp_notify:body_likes_comment:title',array($vars['cp_liked_by'],$vars['cp_comment_from']),'en');
-		$cp_notify_msg_title_fr = elgg_echo('cp_notify:body_likes_comment:title',array($vars['cp_liked_by'],$vars['cp_comment_from']),'fr');
 
-		$cp_notify_msg_description_en = elgg_echo('cp_notify:body_likes_comment:description',array($vars['cp_comment_from'],$vars['cp_liked_by']),'en');
-		$cp_notify_msg_description_fr = elgg_echo('cp_notify:body_likes_comment:description',array($vars['cp_comment_from'],$vars['cp_liked_by']),'fr');
+		$content_title_en = gc_explode_translation($vars['cp_comment_from_en'], 'en');
+		$content_title_fr = gc_explode_translation($vars['cp_comment_from_fr'], 'fr');
+
+		$cp_notify_msg_title_en = elgg_echo('cp_notify:body_likes_comment:title',array($vars['cp_liked_by'], "<a href='{$vars['content_url']}?utm_source=notification&utm_medium=email'>{$content_title_en}</a>"),'en');
+		$cp_notify_msg_title_fr = elgg_echo('cp_notify:body_likes_comment:title',array($vars['cp_liked_by'], "<a href='{$vars['content_url']}?utm_source=notification&utm_medium=email'>{$content_title_fr}</a>"),'fr');
+
+		$cp_notify_msg_description_en = elgg_echo('cp_notify:body_likes_comment:description',array($content_title_en, $vars['cp_liked_by']),'en');
+		$cp_notify_msg_description_fr = elgg_echo('cp_notify:body_likes_comment:description',array($content_title_fr, $vars['cp_liked_by']),'fr');
 
 		break;
 
 
 	case 'cp_likes_topic_replies': // discussion replies
 
-		$cp_notify_msg_title_en = elgg_echo('cp_notify:body_likes_discussion_reply:title',array($vars['cp_liked_by'],$vars['cp_comment_from']),'en');
-		$cp_notify_msg_title_fr = elgg_echo('cp_notify:body_likes_discussion_reply:title',array($vars['cp_liked_by'],$vars['cp_comment_from']),'fr');
+		$content_title_en = gc_explode_translation($vars['cp_comment_from_en'], 'en');
+		$content_title_fr = gc_explode_translation($vars['cp_comment_from_fr'], 'fr');
 
-		$cp_notify_msg_description_en = elgg_echo('cp_notify:body_likes_discussion_reply:description',array($vars['cp_comment_from'],$vars['cp_liked_by']),'en');
-		$cp_notify_msg_description_fr = elgg_echo('cp_notify:body_likes_discussion_reply:description',array($vars['cp_comment_from'],$vars['cp_liked_by']),'fr');
+		$cp_notify_msg_title_en = elgg_echo('cp_notify:body_likes_discussion_reply:title',array($vars['cp_liked_by'], "<a href='{$vars['content_url']}?utm_source=notification&utm_medium=email'>$content_title_en</a>"),'en');
+		$cp_notify_msg_title_fr = elgg_echo('cp_notify:body_likes_discussion_reply:title',array($vars['cp_liked_by'], "<a href='{$vars['content_url']}?utm_source=notification&utm_medium=email'>$content_title_fr</a>"),'fr');
+
+		$cp_notify_msg_description_en = elgg_echo('cp_notify:body_likes_discussion_reply:description',array($content_title_en, $vars['cp_liked_by']),'en');
+		$cp_notify_msg_description_fr = elgg_echo('cp_notify:body_likes_discussion_reply:description',array($content_title_fr, $vars['cp_liked_by']),'fr');
 
 		break;
 

--- a/mod/cp_notifications/views/default/cp_notifications/site_template.php
+++ b/mod/cp_notifications/views/default/cp_notifications/site_template.php
@@ -484,23 +484,45 @@ switch ($msg_type) {
 		break;
 
 
-	case 'cp_likes_comments':
-		$cp_notify_msg_title_en = elgg_echo('cp_notify:body_likes_comment:title',array($vars['cp_liked_by'],$vars['cp_comment_from']),'en');
-		$cp_notify_msg_title_fr = elgg_echo('cp_notify:body_likes_comment:title',array($vars['cp_liked_by'],$vars['cp_comment_from']),'fr');
+	case 'cp_like_group': // like a group
+		$group_name_en = gc_explode_translation($vars['cp_group'], 'en');
+		$group_name_fr = gc_explode_translation($vars['cp_group'], 'fr');
 
-		$cp_notify_msg_description_en = elgg_echo('cp_notify:body_likes_comment:description',array($vars['cp_comment_from'],$vars['cp_liked_by']),'en');
-		$cp_notify_msg_description_fr = elgg_echo('cp_notify:body_likes_comment:description',array($vars['cp_comment_from'],$vars['cp_liked_by']),'fr');
+		$cp_notify_msg_title_en = elgg_echo('cp_notify:body_likes_group:title', array($vars['cp_liked_by'], $group_name_en), 'en');
+		$cp_notify_msg_title_fr = elgg_echo('cp_notify:body_likes_group:title', array($vars['cp_liked_by'], $group_name_fr), 'fr');
+
+		$group_text_en = "<a href='{$vars['cp_group_link']}?utm_source=notification&utm_medium=site'>{$group_name_en}</a>";
+		$group_text_fr = "<a href='{$vars['cp_group_link']}?utm_source=notification&utm_medium=site'>{$group_name_fr}</a>";
+
+		$cp_notify_msg_description_en = elgg_echo('cp_notify:body_likes_group:description', array($group_text_en), 'en');
+		$cp_notify_msg_description_fr = elgg_echo('cp_notify:body_likes_group:description', array($group_text_fr), 'fr');
+		break;
+
+
+	case 'cp_likes_comments':
+
+		$content_title_en = gc_explode_translation($vars['cp_comment_from_en'], 'en');
+		$content_title_fr = gc_explode_translation($vars['cp_comment_from_fr'], 'fr');
+
+		$cp_notify_msg_title_en = elgg_echo('cp_notify:body_likes_comment:title',array($vars['cp_liked_by'], "<a href='{$vars['content_url']}?utm_source=notification&utm_medium=site'>{$content_title_en}</a>"),'en');
+		$cp_notify_msg_title_fr = elgg_echo('cp_notify:body_likes_comment:title',array($vars['cp_liked_by'], "<a href='{$vars['content_url']}?utm_source=notification&utm_medium=site'>{$content_title_fr}</a>"),'fr');
+
+		$cp_notify_msg_description_en = elgg_echo('cp_notify:body_likes_comment:description',array($content_title_en, $vars['cp_liked_by']),'en');
+		$cp_notify_msg_description_fr = elgg_echo('cp_notify:body_likes_comment:description',array($content_title_fr, $vars['cp_liked_by']),'fr');
 
 		break;
 
 
 	case 'cp_likes_topic_replies': // discussion replies
 
-		$cp_notify_msg_title_en = elgg_echo('cp_notify:body_likes_discussion_reply:title',array($vars['cp_liked_by'],$vars['cp_comment_from']),'en');
-		$cp_notify_msg_title_fr = elgg_echo('cp_notify:body_likes_discussion_reply:title',array($vars['cp_liked_by'],$vars['cp_comment_from']),'fr');
+		$content_title_en = gc_explode_translation($vars['cp_comment_from_en'], 'en');
+		$content_title_fr = gc_explode_translation($vars['cp_comment_from_fr'], 'fr');
 
-		$cp_notify_msg_description_en = elgg_echo('cp_notify:body_likes_discussion_reply:description',array($vars['cp_comment_from'],$vars['cp_liked_by']),'en');
-		$cp_notify_msg_description_fr = elgg_echo('cp_notify:body_likes_discussion_reply:description',array($vars['cp_comment_from'],$vars['cp_liked_by']),'fr');
+		$cp_notify_msg_title_en = elgg_echo('cp_notify:body_likes_discussion_reply:title',array($vars['cp_liked_by'], "<a href='{$vars['content_url']}?utm_source=notification&utm_medium=site'>$content_title_en</a>"),'en');
+		$cp_notify_msg_title_fr = elgg_echo('cp_notify:body_likes_discussion_reply:title',array($vars['cp_liked_by'], "<a href='{$vars['content_url']}?utm_source=notification&utm_medium=site'>$content_title_fr</a>"),'fr');
+
+		$cp_notify_msg_description_en = elgg_echo('cp_notify:body_likes_discussion_reply:description',array($content_title_en, $vars['cp_liked_by']),'en');
+		$cp_notify_msg_description_fr = elgg_echo('cp_notify:body_likes_discussion_reply:description',array($content_title_fr, $vars['cp_liked_by']),'fr');
 
 		break;
 

--- a/mod/phpmailer/start.php
+++ b/mod/phpmailer/start.php
@@ -256,7 +256,8 @@ $phpmailer = new PHPMailer(true); //defaults to using php "mail()"; the true par
 
 	if (!$return ) {
 		error_log('PHPMailer error: ' . $phpmailer->ErrorInfo, 'WARNING');
-	} /* else
-		error_log("email sent"); */
+	} else
+		error_log("email sent");
+		
 	return $return;
 }

--- a/mod/phpmailer/start.php
+++ b/mod/phpmailer/start.php
@@ -147,8 +147,7 @@ function phpmailer_send($to, $to_name, $subject, $body, array $bcc = NULL, $html
 	
 	////////////////////////////////////
 	// Format message
-	//$phpmailer->SMTPSecure = "tls";
-	$phpmailer->SMTPDebug = 0; //Set to 1 for debugging information
+	$phpmailer->SMTPDebug = 0; // Set to 1 for debugging information
 
 	$phpmailer->ClearAllRecipients();
 	$phpmailer->ClearAttachments();
@@ -228,7 +227,6 @@ function phpmailer_send($to, $to_name, $subject, $body, array $bcc = NULL, $html
 		$return = $phpmailer->Send();
 
 	} catch (phpmailerException $e) {
-		//error_log($e->errorMessage());
 		
 		$errMess = $e->getMessage();
 		$errStack = $e->getTraceAsString();
@@ -244,9 +242,6 @@ function phpmailer_send($to, $to_name, $subject, $body, array $bcc = NULL, $html
 		$errStack = "";
 		$errType = "custom";
 		phpmailer_logging($errMess, $errStack, 'PHPMailer', $errType);
-
-	} else {
-		//error_log("PHPMailer email sent");
 	}
 
 	return $return;

--- a/mod/phpmailer/start.php
+++ b/mod/phpmailer/start.php
@@ -120,6 +120,7 @@ function phpmailer_send($to, $to_name, $subject, $body, array $bcc = NULL, $html
 	// CONFIGURE SERVER INFORMATION defaults
 	$phpmailer->IsSMTP(); // telling the class to use SMTP
 	$phpmailer->Host       = elgg_get_plugin_setting('phpmailer_host', 'phpmailer'); // SMTP server
+	error_log(">>>>>>>> phpmail host: ".elgg_get_plugin_setting('phpmailer_host', 'phpmailer'));
 	$phpmailer->Port       = elgg_get_plugin_setting('ep_phpmailer_port', 'phpmailer'); // SMTP server port
 	$phpmailer->SMTPAuth   = true;
 	$phpmailer->SMTPSecure = "tls";

--- a/mod/phpmailer/vendors/class.phpmailer.php
+++ b/mod/phpmailer/vendors/class.phpmailer.php
@@ -1516,6 +1516,7 @@ class PHPMailer
      */
     public function getSMTPInstance()
     {
+        require_once elgg_get_plugins_path() . '/phpmailer/vendors/class.smtp.php';
         if (!is_object($this->smtp)) {
             $this->smtp = new SMTP;
         }


### PR DESCRIPTION
@klecuyer (moving your comments to this pull request) issue #1227 

- Notifications are still not sending when I post a blog or file to a group. Users have reported this and I have tested myself in the Sandbox testing group.
https://gcconnex.gc.ca/blog/view/29581794/ennotifications-on-a-blog-againfr

- GCconnex got the notification. My subscribed personal account did not. Also, the 'Do not send a notification' button still sends a notification when checked.

- I can confirm that this group (as well as others) is still experiencing major notification bugs as of today.
https://gcconnex.gc.ca/groups/profile/19651377/enexecutive-corner-carrefour-des-cadres-supu00e9rieursfr . Despite multiple users being subscribed to notifications from this group (and not to the Digest) when a new blog is posted, users are not getting a notification (group of 900+ members). I can log into multiple members' accounts and see no signs of notifications from the blog post. As a workaround, the author is emailing all group members, and after Sending once, the members' are all consistently receiving 4 notifications of the message/email and still none from the original blog post.

- 4x notification bug posted here: #1352 **(this is a separate issue)**
