### PR TITLE
fix(wet4): getSubtype() was lacking ()

### DIFF
--- a/mod/wet4/views/default/object/elements/summary.php
+++ b/mod/wet4/views/default/object/elements/summary.php
@@ -71,7 +71,7 @@ if ($title_link) {
     if(elgg_in_context('widgets')){
         echo "<h4 class=\"mrgn-bttm-0 summary-title\">$title_link</h4>";
     }else if(elgg_in_context('profile') || elgg_in_context('group_profile') || elgg_instanceof(elgg_get_page_owner_entity(), "group")){
-    	if($entity->getSubtype != 'answer'){//if answer in group question
+    	if($entity->getSubtype() != 'answer'){//if answer in group question
     		echo "<h3 class=\"mrgn-bttm-0 summary-title\">$title_link</h3>";
     	}
     }else{


### PR DESCRIPTION
getSubtype() is a function, was lacking () so it was trying to fetch property getSubtype which would usually be empty.
not sure if there's an open issue for this, but it can make titles randomly disappear in lists.
fix from master branch.