### PR TITLE
removed single quotes around vote value field

### DIFF
--- a/mod/wet4/views/default/forms/polls/vote.php
+++ b/mod/wet4/views/default/forms/polls/vote.php
@@ -50,7 +50,7 @@ foreach ($responses3 as $value) {
 	$responses4 = gc_explode_translation($value, $lang);
 
 
-$form_body .="  <input type='radio'  class = 'mrgn-rght-sm' id='responses-".$responses4."' name='response3' value='".$value."'> <label for='responses-".$responses4."'>".$responses4."</label><br>";
+$form_body .="  <input type='radio'  class = 'mrgn-rght-sm' id='responses-".$responses4."' name='response3' value=".$value."> <label for='responses-".$responses4."'>".$responses4."</label><br>";
 }
 
 

--- a/mod/wet4/views/default/forms/polls/vote.php
+++ b/mod/wet4/views/default/forms/polls/vote.php
@@ -50,7 +50,7 @@ foreach ($responses3 as $value) {
 	$responses4 = gc_explode_translation($value, $lang);
 
 
-$form_body .="  <input type='radio'  class = 'mrgn-rght-sm' id='responses-".$responses4."' name='response3' value=".$value."> <label for='responses-".$responses4."'>".$responses4."</label><br>";
+$form_body .="  <input type='radio'  class = 'mrgn-rght-sm' id='responses-".$responses4."' name='response3' value='".htmlEntities($value, ENT_QUOTES)."'> <label for='responses-".$responses4."'>".$responses4."</label><br>";
 }
 
 


### PR DESCRIPTION
Single quotes were the problem with #1355 when the poll option had them as well.

Vote counts that were already affected by this can't be automatically recovered with certainty, but should be doable manually for most cases if necessary.

fixes #1355 and fixes #1363