### PR TITLE
Add autocomplete for group name

### DIFF
--- a/mod/gc_group_layout/views/default/groups/edit/profile.php
+++ b/mod/gc_group_layout/views/default/groups/edit/profile.php
@@ -14,7 +14,6 @@ $description = elgg_extract("description", $vars);
 $group_profile_fields = elgg_get_config("group");
 $group = elgg_extract("entity", $vars);
 
-
 // decode json into English / French parts
 $json_title = json_decode($name);
 $json_desc = json_decode($description);
@@ -84,13 +83,14 @@ echo $btn_language;
     <br />
     <div id="suggestedText"></div>
     <?php
-   /*     //if creating a group
+        //if creating a group
     if(empty($group)){
         echo elgg_view("input/groups_autocomplete", array(
 				'name' => 'name',
 				'value' => elgg_extract('name', $vars),
+                'type' => 'en',
 		));
-    } else {*/
+    } else {
     ?>
 
 	<?php echo elgg_view("input/text", array(
@@ -100,7 +100,7 @@ echo $btn_language;
         'required '=> "required",
         'class' => 'ui-autocomplete-input',
 	));
-   // }?>
+    }?>
 </div>
 
 <!-- title fr -->
@@ -111,13 +111,14 @@ echo $btn_language;
     <br />
     <div id="suggestedText2"></div>
     <?php
-   /*     //if creating a group
+      //if creating a group
     if(empty($group)){
         echo elgg_view("input/groups_autocomplete", array(
-                'name' => 'name2',
-                'value' => elgg_extract('name2', $vars),
+                'name' => 'name',
+                'value' => elgg_extract('name', $vars),
+                'type' => 'fr',
         ));
-    } else {*/
+    } else {
     ?>
 
     <?php echo elgg_view("input/text", array(
@@ -127,7 +128,7 @@ echo $btn_language;
         'required '=> "required",
         'class' => 'ui-autocomplete-input',
     ));
-  //  }?>
+    }?>
 </div>
 
 <div>

--- a/mod/wet4/lib/groups_autocomplete.php
+++ b/mod/wet4/lib/groups_autocomplete.php
@@ -12,6 +12,7 @@
 	$limit = (int) get_input("limit", 50);
 	$result = array();
 	$user = elgg_get_logged_in_user_entity();
+	$lang = get_current_language();
 
 	if(!empty($q)){
 		$db_prefix = elgg_get_config('dbprefix');
@@ -34,9 +35,9 @@
 		foreach($groups as $group){
 			//if (! $group->isMember($user)) {
 				if (! $group->isPublicMembership()) {
-					$result[] = array("type" => "group", "value" => $group->getGUID(),"label" => $group->name,"content" => "<a class=' text-unstyled ' href='".$group->getURL()."'><img class='mrgn-rght-sm' src='" . $group->getIconURL("small") . "' /><span>" . $group->name . "</span></a>", "name" => $group->name);
+					$result[] = array("type" => "group", "value" => $group->getGUID(),"label" => $group->name,"content" => "<a class=' text-unstyled ' href='".$group->getURL()."'><img class='mrgn-rght-sm' src='" . $group->getIconURL("small") . "' /><span>" . gc_explode_translation($group->name,$lang) . "</span></a>", "name" => $group->name);
 				} else {
-					$result[] = array("type" => "group", "value" => $group->getGUID(),"label" => $group->name,"content" => "<a class=' text-unstyled ' href='".$group->getURL()."'><img class='mrgn-rght-sm' src='" . $group->getIconURL("small") . "' /><span>" . $group->name."</span></a>", "name" => $group->name);
+					$result[] = array("type" => "group", "value" => $group->getGUID(),"label" => $group->name,"content" => "<a class=' text-unstyled ' href='".$group->getURL()."'><img class='mrgn-rght-sm' src='" . $group->getIconURL("small") . "' /><span>" . gc_explode_translation($group->name,$lang)."</span></a>", "name" => $group->name);
 				}
 			//}
 		}

--- a/mod/wet4/views/default/input/groups_autocomplete.php
+++ b/mod/wet4/views/default/input/groups_autocomplete.php
@@ -19,19 +19,24 @@
 	elgg_load_css("group_tools.autocomplete");
 	
 	$site_url = elgg_get_site_url();
-?>
+
+	$type = elgg_extract("type", $vars);
+
+ if ($type === 'en'){ ?><!-- If english tab -->
 	<input type="text" name="name" id="<?php echo $id; ?>_autocomplete" class="elgg-input elgg-input-autocomplete" />
+	<?php } else {?><!-- If french tab -->
+	<input type="text" name="name2" id="<?php echo $id; ?>_autocomplete2" class="elgg-input elgg-input-autocomplete" />
+
+	<?php } ?>
 	
 	<div id="<?php echo $destination; ?>"></div>
-		
 	<div class="clearfloat"></div>
-	
 	<script type="text/javascript">
         $(document).ready(function() {
-
-
-
-            $("#<?php echo $id; ?>_autocomplete").each(function(){
+/*If english tab*/
+ <?php if ($type =='en'){ ?> $("#<?php echo $id; ?>_autocomplete").each(function(){ <?php } else { ?>
+/*If french tab*/
+	$("#<?php echo $id; ?>_autocomplete2").each(function(){ <?php  } ?>
 				$(this)
 				// don't navigate away from the field on tab when selecting an item
 				.bind( "keydown", function( event ) {
@@ -52,19 +57,19 @@
 					source: function( request, response ) {
 						$.getJSON( "<?php echo $site_url; ?>groups_autocomplete", {
 							q: request.term,
-							'groups_guids': function() {
-								var result = "";
+							 'groups_guids': function() {
+							 	var result = "";
 
-								$("#<?php echo $destination; ?> input[name='<?php echo $name; ?>[]']").each(function(index, elem){
-									if(result == ""){
+
+							 	$("#<?php echo $destination; ?> input[name='<?php echo $name; ?>[]']").each(function(index, elem){
+							 		if(result == ""){
 										result = $(this).val();
 									} else {
 										result += "," + $(this).val();
-									}
-								});
-
-								return result;
-							}
+							 		}
+							 	});
+							 	return result;
+							 }
 							<?php
 							if(!empty($relationship)){
 								echo ", 'relationship' : '" . $relationship . "'";
@@ -92,7 +97,6 @@
 				    var list_body = "";
 
 				    list_body = item.content;
-
 				    if((item.content).length){
 				        $('#suggestedText').html(' <?php echo elgg_echo('groups:suggestedGroups'); ?> ');
 				    } else {
@@ -103,7 +107,6 @@
 					.data( "item.autocomplete", item )
 					.append( "<a>" + list_body + "</a>" )
 					.appendTo( ul );
-
 				};
         });
 
@@ -113,7 +116,6 @@
                 $('#suggestedText').html(' ');
             }
         });
-
 
         $('#<?php echo $destination; ?> .elgg-icon-delete-alt').live("click", function(){
 				$(this).parent('div').remove();


### PR DESCRIPTION
When a user create a group, they have the autocomplete function for the name. It search in both language and show you the list of group name that have in the language of your page.

Should fix issue #1241 