### PR TITLE
Adding codecov upload to tavis ci and a code coverage badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,9 +43,8 @@ matrix:
        - curl -o - http://localhost:8888/ | grep "<title>Elgg Travis Site</title>"
        - phpunit --coverage-clover=coverage.clover
       after_script:
-       # Report unit test coverage metrics to scrutinizer
-       - wget https://scrutinizer-ci.com/ocular.phar
-       - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+       # Report unit test coverage metrics to codecov.io:
+       - bash <(curl -s https://codecov.io/bash)
 
 services:
  - mysql

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 [![Build Status](https://secure.travis-ci.org/gctools-outilsgc/gcconnex.svg?branch=gcconnex)](https://travis-ci.org/gctools-outilsgc/gcconnex)
 [![Join the chat at https://gitter.im/gctools-outilsgc/gcconnex](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/gctools-outilsgc/general?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![codecov](https://codecov.io/gh/gctools-outilsgc/gcconnex/branch/gcconnex/graph/badge.svg)](https://codecov.io/gh/gctools-outilsgc/gcconnex)
 
 GCconnex is a professional networking and collaborative workspace for all Canadian public service, allowing people to connect and share information, leveraging the power of networking towards a more effective and efficient public service.
 


### PR DESCRIPTION
We don't have a scrutinizer subscription, replacing it with codecov