### PR TITLE
Modified the access input on profile opt in section

### DIFF
--- a/mod/b_extended_profile/languages/en.php
+++ b/mod/b_extended_profile/languages/en.php
@@ -53,6 +53,7 @@ $english = array(
     'gcconnex_profile:present' => 'Present', // for work and education time ranges.. from XX date to Present
     'gcconnex_profile:about_me:empty' => 'Begin entering a description about yourself by clicking "Edit" in the top right corner of this box.',// prompt to add first skill
     'gcconnex_profile:about_me:access' => 'Who can see my description',
+    'missions:profile:optin:access' => 'This information will be used by the Opportunities Platform and will not be visible to users browsing your profile.',
 
     // BASIC INFORMATION PROFILE FORM
     'gcconnex_profile:basic:header' => 'Edit Basic Profile',

--- a/mod/b_extended_profile/languages/en.php
+++ b/mod/b_extended_profile/languages/en.php
@@ -53,7 +53,7 @@ $english = array(
     'gcconnex_profile:present' => 'Present', // for work and education time ranges.. from XX date to Present
     'gcconnex_profile:about_me:empty' => 'Begin entering a description about yourself by clicking "Edit" in the top right corner of this box.',// prompt to add first skill
     'gcconnex_profile:about_me:access' => 'Who can see my description',
-    'missions:profile:optin:access' => 'This information will be used by the Opportunities Platform and will not be visible to users browsing your profile.',
+    'gcconnex_profile:optin:access' => 'This information will be used by the Opportunities Platform and will not be visible to users browsing your profile.',
 
     // BASIC INFORMATION PROFILE FORM
     'gcconnex_profile:basic:header' => 'Edit Basic Profile',

--- a/mod/b_extended_profile/languages/fr.php
+++ b/mod/b_extended_profile/languages/fr.php
@@ -54,6 +54,7 @@ $french = array(
     'gcconnex_profile:present' => 'Maintenant',
     'gcconnex_profile:about_me:empty' => 'Ajoutez des précisions à votre sujet en cliquant sur « Modifier » dans le coin supérieur droit de cette section.',
     'gcconnex_profile:about_me:access' => 'Accès aux renseignements à mon sujet ',
+    'missions:profile:optin:access' => 'This information will be used by the Opportunities Platform and will not be visible to users browsing your profile.(FR)',
 
     // BASIC PROFILE FORM
     'gcconnex_profile:basic:header' => 'Modifier le profil de base',

--- a/mod/b_extended_profile/languages/fr.php
+++ b/mod/b_extended_profile/languages/fr.php
@@ -54,7 +54,7 @@ $french = array(
     'gcconnex_profile:present' => 'Maintenant',
     'gcconnex_profile:about_me:empty' => 'Ajoutez des précisions à votre sujet en cliquant sur « Modifier » dans le coin supérieur droit de cette section.',
     'gcconnex_profile:about_me:access' => 'Accès aux renseignements à mon sujet ',
-    'missions:profile:optin:access' => 'This information will be used by the Opportunities Platform and will not be visible to users browsing your profile.(FR)',
+    'gcconnex_profile:optin:access' => "Ces informations seront utilisées pour la Plateforme de possibilités et ne seront pas visibles par les utilisateurs qui naviguent sur votre profil.",
 
     // BASIC PROFILE FORM
     'gcconnex_profile:basic:header' => 'Modifier le profil de base',

--- a/mod/b_extended_profile/views/default/b_extended_profile/edit_opt-in.php
+++ b/mod/b_extended_profile/views/default/b_extended_profile/edit_opt-in.php
@@ -13,33 +13,14 @@
  * This view displays a form which allows the user to edit their opt-in choices.
  * This view is inside a section wrapper as described in wrapper.php.
  */
-if (elgg_is_xhr) {	
+if (elgg_is_xhr) {
 	$user_guid = elgg_get_logged_in_user_guid();
 	$user = get_user ( $user_guid );
 
-	echo elgg_format_element('div',array('class'=> 'mrgn-bttm-sm mrgn-tp-sm alert alert-info'),elgg_echo('missions:profile:optin:access'));
-	// Decides whether or not the checkbox should start checked.
-	/*if($user->opt_in_missions == 'gcconnex_profile:opt:yes') {
-	    $opt_in_set[0] = true;
-	}
-	if($user->opt_in_swap == 'gcconnex_profile:opt:yes') {
-	    $opt_in_set[1] = true;
-	}
-	if($user->opt_in_mentored == 'gcconnex_profile:opt:yes') {
-	    $opt_in_set[2] = true;
-	}
-	if($user->opt_in_mentoring == 'gcconnex_profile:opt:yes') {
-	    $opt_in_set[3] = true;
-	}
-	if($user->opt_in_shadowed == 'gcconnex_profile:opt:yes') {
-	    $opt_in_set[4] = true;
-	}
-	if($user->opt_in_shadowing == 'gcconnex_profile:opt:yes') {
-	    $opt_in_set[5] = true;
-	}*/
-    
-    
-                $opt_in_set = array($user->opt_in_missions, $user->opt_in_swap, $user->opt_in_mentored, $user->opt_in_mentoring, $user->opt_in_shadowed, $user->opt_in_shadowing, $user->opt_in_jobshare, $user->opt_in_pcSeek, $user->opt_in_pcCreate, $user->opt_in_ssSeek, $user->opt_in_ssCreate, $user->opt_in_rotation, $user->opt_in_assignSeek, $user->opt_in_assignCreate, $user->opt_in_deploySeek, $user->opt_in_deployCreate, $user->opt_in_missionCreate);
+	echo elgg_format_element('div',array('class'=> 'mrgn-bttm-sm mrgn-tp-sm alert alert-info'),elgg_echo('gcconnex_profile:optin:access'));
+
+
+	 $opt_in_set = array($user->opt_in_missions, $user->opt_in_swap, $user->opt_in_mentored, $user->opt_in_mentoring, $user->opt_in_shadowed, $user->opt_in_shadowing, $user->opt_in_jobshare, $user->opt_in_pcSeek, $user->opt_in_pcCreate, $user->opt_in_ssSeek, $user->opt_in_ssCreate, $user->opt_in_rotation, $user->opt_in_assignSeek, $user->opt_in_assignCreate, $user->opt_in_deploySeek, $user->opt_in_deployCreate, $user->opt_in_missionCreate);
     //Nick - Loop through array of selected things and change their value to match the meta data        
 foreach($opt_in_set as $k => $v){
     if($v == 'gcconnex_profile:opt:yes'){

--- a/mod/b_extended_profile/views/default/b_extended_profile/edit_opt-in.php
+++ b/mod/b_extended_profile/views/default/b_extended_profile/edit_opt-in.php
@@ -13,20 +13,11 @@
  * This view displays a form which allows the user to edit their opt-in choices.
  * This view is inside a section wrapper as described in wrapper.php.
  */
-if (elgg_is_xhr) {
-	echo elgg_echo ( 'gcconnex_profile:opt:opt_in_access' );
-	
+if (elgg_is_xhr) {	
 	$user_guid = elgg_get_logged_in_user_guid();
 	$user = get_user ( $user_guid );
-	
-	$access_id = $user->optaccess;
-	$params = array (
-			'name' => "accesslevel['optaccess']",
-			'value' => $access_id,
-			'class' => 'gcconnex-opt-in-access' 
-	);
-	echo elgg_view ( 'input/access', $params );
-	
+
+	echo elgg_format_element('div',array('class'=> 'mrgn-bttm-sm mrgn-tp-sm alert alert-info'),elgg_echo('missions:profile:optin:access'));
 	// Decides whether or not the checkbox should start checked.
 	/*if($user->opt_in_missions == 'gcconnex_profile:opt:yes') {
 	    $opt_in_set[0] = true;

--- a/mod/b_extended_profile/views/default/b_extended_profile/edit_opt-in.php
+++ b/mod/b_extended_profile/views/default/b_extended_profile/edit_opt-in.php
@@ -20,7 +20,7 @@ if (elgg_is_xhr) {
 	echo elgg_format_element('div',array('class'=> 'mrgn-bttm-sm mrgn-tp-sm alert alert-info'),elgg_echo('gcconnex_profile:optin:access'));
 
 
-	 $opt_in_set = array($user->opt_in_missions, $user->opt_in_swap, $user->opt_in_mentored, $user->opt_in_mentoring, $user->opt_in_shadowed, $user->opt_in_shadowing, $user->opt_in_jobshare, $user->opt_in_pcSeek, $user->opt_in_pcCreate, $user->opt_in_ssSeek, $user->opt_in_ssCreate, $user->opt_in_rotation, $user->opt_in_assignSeek, $user->opt_in_assignCreate, $user->opt_in_deploySeek, $user->opt_in_deployCreate, $user->opt_in_missionCreate);
+	$opt_in_set = array($user->opt_in_missions, $user->opt_in_swap, $user->opt_in_mentored, $user->opt_in_mentoring, $user->opt_in_shadowed, $user->opt_in_shadowing, $user->opt_in_jobshare, $user->opt_in_pcSeek, $user->opt_in_pcCreate, $user->opt_in_ssSeek, $user->opt_in_ssCreate, $user->opt_in_rotation, $user->opt_in_assignSeek, $user->opt_in_assignCreate, $user->opt_in_deploySeek, $user->opt_in_deployCreate, $user->opt_in_missionCreate);
     //Nick - Loop through array of selected things and change their value to match the meta data        
 foreach($opt_in_set as $k => $v){
     if($v == 'gcconnex_profile:opt:yes'){


### PR DESCRIPTION
When a user is editing their opportunities platform opt in settings through their profile, the access input is now replaced with text information.

Closes #1296 

Will also need translation for the text @LemieuxGen 