### PR TITLE
Hide activity group in sidebar 

### DIFF
--- a/mod/gc_group_layout/views/default/groups/sidebar/sidebar.php
+++ b/mod/gc_group_layout/views/default/groups/sidebar/sidebar.php
@@ -16,8 +16,10 @@ if($display_members != 'yes'){
   echo elgg_view('groups/sidebar/group_members', $vars);
 }
 
-//group activity
-echo elgg_view('groups/sidebar/activity', $vars);
+if (elgg_group_gatekeeper(false)) {
+    //group activity
+    echo elgg_view('groups/sidebar/activity', $vars);
+}
 
 //subgroups
 //I'll have to test if the user has sub groups and related groups active


### PR DESCRIPTION
Hide activity group in sidebar if user can't see the content of the group.

Issue #1578 