### PR TITLE
Update group member and operator access

### DIFF
--- a/engine/lib/navigation.php
+++ b/engine/lib/navigation.php
@@ -471,9 +471,8 @@ function _elgg_entity_menu_setup($hook, $type, $return, $params) {
 		);
 		$return[] = \ElggMenuItem::factory($options);
 	}
-	$user = elgg_get_logged_in_user_entity();
+	
 	if ($entity->canEdit() && $handler) {
-		if ($entity['owner_guid'] == $user['guid'] || elgg_is_admin_logged_in()){
 			// edit link
 			$options = array(
 				'name' => 'edit',
@@ -496,7 +495,6 @@ function _elgg_entity_menu_setup($hook, $type, $return, $params) {
 				);
 				$return[] = \ElggMenuItem::factory($options);
 			}
-		}
 	}
 
 

--- a/engine/lib/navigation.php
+++ b/engine/lib/navigation.php
@@ -473,30 +473,61 @@ function _elgg_entity_menu_setup($hook, $type, $return, $params) {
 	}
 	
 	if ($entity->canEdit() && $handler) {
-			// edit link
-			$options = array(
-				'name' => 'edit',
-				'text' => elgg_echo('edit'),
-				'title' => elgg_echo('edit:this'),
-				'href' => "$handler/edit/{$entity->getGUID()}",
-				'priority' => 200,
-			);
-			$return[] = \ElggMenuItem::factory($options);
 
-			if(elgg_is_logged_in()){
-				// delete link
+			// edit link
+		$user = elgg_get_logged_in_user_entity();
+        $page_owner = elgg_get_page_owner_entity();
+            if($entity->getSubtype() == 'discussion_reply' ){
+                if($entity->owner_guid == $user['guid'] || elgg_is_admin_logged_in() || ($page_owner instanceof ElggGroup && $page_owner->getOwnerGUID() == $user['guid']) || $page_owner->canEdit()){
+					$options = array(
+						'name' => 'edit',
+						'text' => elgg_echo('edit'),
+						'title' => elgg_echo('edit:this'),
+						'href' => "$handler/edit/{$entity->getGUID()}",
+						'priority' => 200,
+					);
+					$return[] = \ElggMenuItem::factory($options);
+
+					if(elgg_is_logged_in()){
+
+						// delete link
+						$options = array(
+							'name' => 'delete',
+							'text' => elgg_view_icon('delete'),
+							'title' => elgg_echo('delete:this'),
+							'href' => "action/$handler/delete?guid={$entity->getGUID()}",
+							'confirm' => elgg_echo('deleteconfirm'),
+							'priority' => 300,
+						);
+						$return[] = \ElggMenuItem::factory($options);
+					}
+				}
+			}else{
+
 				$options = array(
-					'name' => 'delete',
-					'text' => elgg_view_icon('delete'),
-					'title' => elgg_echo('delete:this'),
-					'href' => "action/$handler/delete?guid={$entity->getGUID()}",
-					'confirm' => elgg_echo('deleteconfirm'),
-					'priority' => 300,
+					'name' => 'edit',
+					'text' => elgg_echo('edit'),
+					'title' => elgg_echo('edit:this'),
+					'href' => "$handler/edit/{$entity->getGUID()}",
+					'priority' => 200,
 				);
 				$return[] = \ElggMenuItem::factory($options);
-			}
-	}
 
+				if(elgg_is_logged_in()){
+
+					// delete link
+					$options = array(
+						'name' => 'delete',
+						'text' => elgg_view_icon('delete'),
+						'title' => elgg_echo('delete:this'),
+						'href' => "action/$handler/delete?guid={$entity->getGUID()}",
+						'confirm' => elgg_echo('deleteconfirm'),
+						'priority' => 300,
+					);
+					$return[] = \ElggMenuItem::factory($options);
+				}
+			}
+		}
 
 	return $return;
 }

--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -1254,6 +1254,10 @@ function discussion_reply_menu_setup($hook, $type, $return, $params) {
 	// Allow discussion topic owner, group owner and admins to edit and delete
 	if ($reply->canEdit() && !elgg_in_context('activity')) {
 
+	$user = elgg_get_logged_in_user_entity();
+    $page_owner = elgg_get_page_owner_entity();
+		if($entity->owner_guid == $user['guid'] || elgg_is_admin_logged_in() || ($page_owner instanceof ElggGroup && $page_owner->getOwnerGUID() == $user['guid']) || $page_owner->canEdit()){
+                    
 			$return[] = ElggMenuItem::factory(array(
 				'name' => 'edit',
 				'text' => elgg_echo('edit'),
@@ -1269,6 +1273,7 @@ function discussion_reply_menu_setup($hook, $type, $return, $params) {
 				'is_action' => true,
 				'confirm' => elgg_echo('deleteconfirm'),
 			));
+		}
 		
 	} else {
 		// Edit and delete links can be removed from all other users

--- a/mod/groups/start.php
+++ b/mod/groups/start.php
@@ -1251,11 +1251,9 @@ function discussion_reply_menu_setup($hook, $type, $return, $params) {
 	// Reply has the same access as the topic so no need to view it
 	$remove = array('access');
 
-	$user = elgg_get_logged_in_user_entity();
-
 	// Allow discussion topic owner, group owner and admins to edit and delete
 	if ($reply->canEdit() && !elgg_in_context('activity')) {
-		if ($reply['owner_guid'] == $user['guid'] || elgg_is_admin_logged_in()){
+
 			$return[] = ElggMenuItem::factory(array(
 				'name' => 'edit',
 				'text' => elgg_echo('edit'),
@@ -1271,7 +1269,7 @@ function discussion_reply_menu_setup($hook, $type, $return, $params) {
 				'is_action' => true,
 				'confirm' => elgg_echo('deleteconfirm'),
 			));
-		}
+		
 	} else {
 		// Edit and delete links can be removed from all other users
 		$remove[] = 'edit';

--- a/mod/wet4/start.php
+++ b/mod/wet4/start.php
@@ -1000,7 +1000,7 @@ function wet4_elgg_entity_menu_setup($hook, $type, $return, $params) {
 	if ($entity->canEdit() && $handler) {
         //checks so the edit icon is not placed on incorrect entities
       if($handler != 'group_operators'){
-            if($entity->getSubtype() != 'thewire' || $entity->getSubtype() != 'discussion_reply'){
+            if($entity->getSubtype() != 'thewire' && $entity->getSubtype() != 'discussion_reply'){
                 $options = array(
                     'name' => 'edit',
                     'text' => '<i class="fa fa-edit fa-lg icon-unsel"><span class="wb-inv">'.$hiddenText['edit'].'</span></i>',

--- a/mod/wet4/start.php
+++ b/mod/wet4/start.php
@@ -1029,7 +1029,6 @@ function wet4_elgg_entity_menu_setup($hook, $type, $return, $params) {
                 $page_owner = elgg_get_page_owner_entity();
                 if($entity->getSubtype() == 'discussion_reply' ){
                     if($entity->owner_guid == $user['guid'] || elgg_is_admin_logged_in() || ($page_owner instanceof ElggGroup && $page_owner->getOwnerGUID() == $user['guid']) || $page_owner->canEdit()){
-                    echo $entity->owner_guid;
                     $options = array(
                     'name' => 'edit',
                     'text' => '<i class="fa fa-edit fa-lg icon-unsel"><span class="wb-inv">'.$hiddenText['edit'].'</span></i>',

--- a/mod/wet4/start.php
+++ b/mod/wet4/start.php
@@ -996,12 +996,10 @@ function wet4_elgg_entity_menu_setup($hook, $type, $return, $params) {
                 );
                 $return[] = ElggMenuItem::factory($options);
             }
-    $user = elgg_get_logged_in_user_entity();
+  
 	if ($entity->canEdit() && $handler) {
-         if ($entity['owner_guid'] == $user['guid'] || elgg_is_admin_logged_in()){
-
         //checks so the edit icon is not placed on incorrect entities
-     
+      if($handler != 'group_operators'){
             if($entity->getSubtype() != 'thewire'){
                 $options = array(
                     'name' => 'edit',
@@ -1025,8 +1023,8 @@ function wet4_elgg_entity_menu_setup($hook, $type, $return, $params) {
         		);
         		$return[] = \ElggMenuItem::factory($options);
             }
-	}
-}
+        }
+    }
 
     if($entity->getSubType() == 'file'){
         // download link

--- a/mod/wet4/start.php
+++ b/mod/wet4/start.php
@@ -1000,7 +1000,7 @@ function wet4_elgg_entity_menu_setup($hook, $type, $return, $params) {
 	if ($entity->canEdit() && $handler) {
         //checks so the edit icon is not placed on incorrect entities
       if($handler != 'group_operators'){
-            if($entity->getSubtype() != 'thewire'){
+            if($entity->getSubtype() != 'thewire' || $entity->getSubtype() != 'discussion_reply'){
                 $options = array(
                     'name' => 'edit',
                     'text' => '<i class="fa fa-edit fa-lg icon-unsel"><span class="wb-inv">'.$hiddenText['edit'].'</span></i>',
@@ -1012,16 +1012,44 @@ function wet4_elgg_entity_menu_setup($hook, $type, $return, $params) {
             }
 		// delete link
 
+            if (elgg_is_logged_in() && $entity->getSubtype() != 'discussion_reply'){
+            		$options = array(
+            			'name' => 'delete',
+            			'text' => '<i class="fa fa-trash-o fa-lg icon-unsel"><span class="wb-inv">'.$hiddenText['delete'].'</span></i>',
+            			'title' => elgg_echo('delete:this') . ' ' . $entContext,
+            			'href' => "action/$handler/delete?guid={$entity->getGUID()}",
+            			'confirm' => elgg_echo('deleteconfirm'),
+            			'priority' => 300,
+            		);
+            		$return[] = \ElggMenuItem::factory($options);
+                    }
+
             if (elgg_is_logged_in()){
-        		$options = array(
-        			'name' => 'delete',
-        			'text' => '<i class="fa fa-trash-o fa-lg icon-unsel"><span class="wb-inv">'.$hiddenText['delete'].'</span></i>',
-        			'title' => elgg_echo('delete:this') . ' ' . $entContext,
-        			'href' => "action/$handler/delete?guid={$entity->getGUID()}",
-        			'confirm' => elgg_echo('deleteconfirm'),
-        			'priority' => 300,
-        		);
-        		$return[] = \ElggMenuItem::factory($options);
+                $user = elgg_get_logged_in_user_entity();
+                $page_owner = elgg_get_page_owner_entity();
+                if($entity->getSubtype() == 'discussion_reply' ){
+                    if($entity->owner_guid == $user['guid'] || elgg_is_admin_logged_in() || ($page_owner instanceof ElggGroup && $page_owner->getOwnerGUID() == $user['guid']) || $page_owner->canEdit()){
+                    echo $entity->owner_guid;
+                    $options = array(
+                    'name' => 'edit',
+                    'text' => '<i class="fa fa-edit fa-lg icon-unsel"><span class="wb-inv">'.$hiddenText['edit'].'</span></i>',
+                    'title' => elgg_echo('edit:this') . ' ' . $entContext,
+                    'href' => "$handler/edit/{$entity->getGUID()}",
+                    'priority' => 299,
+                );
+                $return[] = \ElggMenuItem::factory($options);
+
+                    $options = array(
+                        'name' => 'delete',
+                        'text' => '<i class="fa fa-trash-o fa-lg icon-unsel"><span class="wb-inv">'.$hiddenText['delete'].'</span></i>',
+                        'title' => elgg_echo('delete:this') . ' ' . $entContext,
+                        'href' => "action/$handler/delete?guid={$entity->getGUID()}",
+                        'confirm' => elgg_echo('deleteconfirm'),
+                        'priority' => 300,
+                    );
+                    $return[] = \ElggMenuItem::factory($options);
+                    }
+                }
             }
         }
     }

--- a/mod/wet4/views/default/forms/groups/edit.php
+++ b/mod/wet4/views/default/forms/groups/edit.php
@@ -50,15 +50,18 @@ if ($entity) {
 } else {
     echo elgg_view("input/submit", array("value" => elgg_echo("gprofile:create"), 'class' => 'btn btn-primary',));
 }
-
+$user = elgg_get_logged_in_user_entity();
 if ($entity) {
-	$delete_url = "action/groups/delete?guid=" . $entity->getGUID();
-	echo elgg_view("output/url", array(
-		"text" => elgg_echo("groups:delete"),
-		"href" => $delete_url,
-		"confirm" => elgg_echo("groups:deletewarning"),
-		"class" => "elgg-button elgg-button-delete float-alt",
-	));
+
+	if($user['guid'] ==  $entity['owner_guid'] || elgg_is_admin_logged_in()){
+		$delete_url = "action/groups/delete?guid=" . $entity->getGUID();
+		echo elgg_view("output/url", array(
+			"text" => elgg_echo("groups:delete"),
+			"href" => $delete_url,
+			"confirm" => elgg_echo("groups:deletewarning"),
+			"class" => "elgg-button elgg-button-delete float-alt",
+		));
+	}
 }
 
 elgg_pop_context();


### PR DESCRIPTION
Fix issue #1604 
Fix issue Phanoix/gcconnex-help#32

This fix remove the change from the merge #1595 
A regular user should not be able to edit or delete reply form other user even if the user create the discussion. Only the group owner, group operator and admin can do this.

Alors, a group operator can't delete the group, only admin and group owner.