### PR TITLE
added missing fields to export, email in particular

### DIFF
--- a/mod/missions/api/v0/api.php
+++ b/mod/missions/api/v0/api.php
@@ -123,6 +123,8 @@ $since = null, $before = null, $limit = null, $resume = null, $sort = false) {
 */
 function mm_api_entity_export($entity_guids) {
   function exportEntity($entity_or_guid) {
+    // List of fields not to include in any export
+    $omit = array('password', 'password_hash', 'salt');
     if (is_object($entity_or_guid)) {
       $entity = $entity_or_guid;
     } else {
@@ -138,6 +140,11 @@ function mm_api_entity_export($entity_guids) {
     $exportable_values = $entity->getExportableValues();
     foreach ($exportable_values as $v) {
       $ret->$v = $entity->$v;
+    }
+    foreach ($entity as $field=>$value) {
+      if (!in_array($field, $exportable_values) && !in_array($field, $omit)) {
+        $ret->$field = $value;
+      }
     }
     $ret->url = $entity->getURL();
     $ret->subtype_name = $entity->getSubtype();


### PR DESCRIPTION
noticed not all fields are considered "exportable" by elgg - the recommendation API needs everything... in particular the "email" field was not being exported with users.... 

This PR solves that by adding any missing fields to the export - but it also removes things like password and password_hash that we certainly don't need.

@Troy-Lawson please schedule this to be merged at your earliest convenience, it has no side-effects.