### PR TITLE
Encoding for message reply

### DIFF
--- a/mod/wet4/pages/messages/read.php
+++ b/mod/wet4/pages/messages/read.php
@@ -18,7 +18,7 @@ elgg_entity_gatekeeper($guid, 'object', 'messages');
 $message = get_entity($guid);
 $from_user = get_user($message->fromId);
 $to_user = get_user($message->toId);
-
+$page_title = utf8_decode($message->title);
 // mark the message as read
 $message->readYet = true;
 
@@ -44,7 +44,7 @@ elgg_push_breadcrumb($title);
 	//$from_user->name = utf8_encode($from_user->name);
 //}
 
-$message->title = utf8_encode($message->title);
+//$title = utf8_encode($message->title);
 
 $content = elgg_view_entity($message, array('full_view' => true));
 
@@ -74,4 +74,4 @@ $body = elgg_view_layout('one_column', array(
 	'filter' => '',
 ));
 
-echo elgg_view_page($title, $body);
+echo elgg_view_page($page_title, $body);

--- a/mod/wet4/views/default/forms/messages/reply.php
+++ b/mod/wet4/views/default/forms/messages/reply.php
@@ -10,7 +10,7 @@
  * Author: GCTools Team
  */
 // fix for RE: RE: RE: that builds on replies
-$reply_title = $vars['message']->title;
+$reply_title = utf8_decode($vars['message']->title);
 if (strncmp($reply_title, "RE:", 3) != 0) {
 	$reply_title = "RE: " . $reply_title;
 }

--- a/mod/wet4/views/default/forms/messages/reply.php
+++ b/mod/wet4/views/default/forms/messages/reply.php
@@ -10,7 +10,7 @@
  * Author: GCTools Team
  */
 // fix for RE: RE: RE: that builds on replies
-$reply_title = utf8_decode($vars['message']->title);
+$reply_title = $vars['message']->title;
 if (strncmp($reply_title, "RE:", 3) != 0) {
 	$reply_title = "RE: " . $reply_title;
 }

--- a/mod/wet4/views/default/object/messages.php
+++ b/mod/wet4/views/default/object/messages.php
@@ -107,7 +107,7 @@ if ($full) {
         $user_link = '<b>' . $user->name . '</b>';
 
 
-    $subject_info = utf8_decode('<b>' . elgg_echo('messages:title') . ':</b> ' . $message->title);
+    $subject_info = '<b>' . elgg_echo('messages:title') . ':</b> ' . $message->title;
 
     //lets redo the body here
     $body = <<<HTML


### PR DESCRIPTION
Fixes #1617 
Fixes Phanoix/gcconnex-help#37

When replying to a site message with accented characters it would not encode them causing characters like ã© instead of é to appear in the subject.
