### PR TITLE
fix: Typo/grammar: replace 'entitled' with 'titled'

### DIFF
--- a/mod/cp_notifications/languages/en.php
+++ b/mod/cp_notifications/languages/en.php
@@ -75,8 +75,8 @@ $english = array(
 	'cp_notifications:mail_body:subtype:file' => "%s posted a file: %s", 
 
 	'cp_notifications:mail_body:subtype:album' => "%s posted an album: %s", 
-	'cp_notifications:mail_body:subtype:thewire' => "%s posted a new %s message entitled:",
-	'cp_notifications:mail_body:subtype:thewire_digest' => "%s posted a new %s message entitled: %s",
+	'cp_notifications:mail_body:subtype:thewire' => "%s posted a new %s message titled:",
+	'cp_notifications:mail_body:subtype:thewire_digest' => "%s posted a new %s message titled: %s",
 	
 	'cp_notifications:mail_body:subtype:thewireSubj' => "%s posted a new %s message",
 	
@@ -265,8 +265,8 @@ $english = array(
 
 
 	// group mail section
-	'cp_notify:subject:group_mail' => "You have received a message entitled '%s' from the group '%s'",
-	'cp_notify:body_group_mail:title' => "You have received a message entitled '%s' from the group '%s'",
+	'cp_notify:subject:group_mail' => "You have received a message titled '%s' from the group '%s'",
+	'cp_notify:body_group_mail:title' => "You have received a message titled '%s' from the group '%s'",
 	'cp_notify:body_group_mail:description' => "The group owner or administrator has sent the following message: <br/>
 		%s",
 
@@ -327,7 +327,7 @@ $english = array(
 
 	// site message section
 	'cp_notify:subject:site_message' => "%s sent you a new message '%s'",
-	'cp_notify:body_site_msg:title' => "%s sent you a site message entitled '%s'",
+	'cp_notify:body_site_msg:title' => "%s sent you a site message titled '%s'",
 	'cp_notify:body_site_msg:description' => "The content of the message is: <br/>
 		%s <br/>
 		You can view or reply to this by clicking on this link: %s",
@@ -343,10 +343,10 @@ $english = array(
 	'cp_notify_usr:subject:new_content2' => "%s posted a new %s",
 	'cp_notify:subject:new_content' => "A new %s was posted in group %s",
 
-	// +------ cyu - modified : <username> posted a new <item type> entitled <item name>
-	'cp_notify:body_new_content:title' => "<a href='%s'>%s</a> posted a new %s entitled <a href='%s'>%s</a>",
+	// +------ cyu - modified : <username> posted a new <item type> titled <item name>
+	'cp_notify:body_new_content:title' => "<a href='%s'>%s</a> posted a new %s titled <a href='%s'>%s</a>",
 	'cp_notify:body_new_content:title2' => "<a href='%s'>%s</a> posted a new %s in <a href='%s'>%s</a>",
-	'cp_notify:body_new_content:title3' => "<a href='%s'>%s</a> posted a new %s message entitled",
+	'cp_notify:body_new_content:title3' => "<a href='%s'>%s</a> posted a new %s message titled",
 
 	
 
@@ -365,7 +365,7 @@ $english = array(
 
 	// mentioned section
 	'cp_notify:subject:mention' => "%s mentioned you on GCconnex",
-	'cp_notify:body_mention:title' => "%s mentioned you in their post or reply entitled '%s'",
+	'cp_notify:body_mention:title' => "%s mentioned you in their post or reply titled '%s'",
 	'cp_notify:body_mention:description' => "Here is the post where you were mentioned: <br/>
 		%s <br/>
 		You can view or reply to this post by clicking on this link: %s",

--- a/mod/cp_notifications/languages/fr.php
+++ b/mod/cp_notifications/languages/fr.php
@@ -373,7 +373,7 @@ $french = array(
 	'cp_notify:subject:new_content_mas2' => "Un nouvel %s a été affiché dans le groupe %s",
 	'cp_notify:subject:new_content_fem' => "Une nouvelle %s a été affichée dans le groupe %s",
 
-	// +------ cyu <User name> posted a new <item type> entitled <item name>
+	// +------ cyu <User name> posted a new <item type> titled <item name>
 	'cp_notify:body_new_content:title_m' => "<a href='%s'>%s</a> a affiché un nouveau %s intitulé <a href='%s'>%s</a>",
 	'cp_notify:body_new_content:title_f' => "<a href='%s'>%s</a> a affiché une nouvelle %s intitulée <a href='%s'>%s</a>",
 

--- a/mod/wet4/views/default/messages/message_preview.php
+++ b/mod/wet4/views/default/messages/message_preview.php
@@ -21,7 +21,7 @@
    $('.desc').html(body);
 
     //the title
-   var eng_title = sender + " sent you a site message entitled '" + subject + "'";
+   var eng_title = sender + " sent you a site message titled '" + subject + "'";
    $('.eng-title').html(eng_title);
    var fr_title = sender + " vous a envoy&#233; un message intitul&#233; '" + subject + "'";
    $('.fr-title').html(fr_title);

--- a/mod/wet4_collab/views/default/messages/message_preview.php
+++ b/mod/wet4_collab/views/default/messages/message_preview.php
@@ -21,7 +21,7 @@
    $('.desc').html(body);
 
     //the title
-   var eng_title = sender + " sent you a site message entitled '" + subject + "'";
+   var eng_title = sender + " sent you a site message titled '" + subject + "'";
    $('.eng-title').html(eng_title);
    var fr_title = sender + " vous a envoy&#233; un message intitul&#233; '" + subject + "'";
    $('.fr-title').html(fr_title);


### PR DESCRIPTION
changed `entitled` to `titled` where I have been able to find it. As per issue #1667 