### PR TITLE
Docker automation, image update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN \
     php5-mysql \
     php5-xml \
   && apk update \
-  && apk --no-cache add php5-mysqli=5.6.32-r2 \
+  && apk --no-cache add php5-mysqli \
   && mkdir -p /var/www/html/vendor \
   && mkdir -p /data \
   && mkdir -p /run/apache2 \
@@ -50,7 +50,8 @@ RUN \
 
 COPY ./install/config/htaccess.dist /var/www/html/.htaccess
 COPY --from=0 /app/vendor/ /var/www/html/vendor/
-COPY --chown=apache . /var/www/html
+COPY . /var/www/html
+RUN chown apache:apache /var/www/html
 
 WORKDIR /var/www/html
 EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,12 @@ COPY --chown=apache . /var/www/html
 
 WORKDIR /var/www/html
 EXPOSE 80
+EXPOSE 443
+
+RUN chmod +x docker/start.sh
 
 # Start Apache in foreground mode
-CMD rm -f /run/apache2/httpd.pid && /usr/sbin/httpd -D FOREGROUND
+RUN rm -f /run/apache2/httpd.pid
+ENTRYPOINT [ "docker/start.sh" ]
+CMD  ["/usr/sbin/httpd -D FOREGROUND"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ LABEL maintainer="Luc Belliveau <luc.belliveau@nrc-cnrc.gc.ca>"
 RUN \
   apk --no-cache add \
     apache2 \
+    php5 \
     php5-apache2 \
     php5-ctype \
     php5-curl \

--- a/README.md
+++ b/README.md
@@ -37,14 +37,9 @@ use docker-compose to start/create your containers.
 
     docker-compose up
 
-Then visit [http://localhost:8080](http://localhost:8080) and follow the
-instructions to complete your installation.  Once the installer is complete,
-refer to [INSTALL.md](INSTALL.md#configure-plugins) to configure the plugins
-required by GCconnex.
+and add an entry for ```<host ip> gcconnex.local``` in your hosts file.
+Then visit [http://gcconnex.local](http://gcconnex.local) which should by now be a fully set up dev environment.
 
-Alternatively, you can use the automated install script which will run the regular install as well as installing and rearanging the gcconnex mods:
-
-    docker exec -it gcconnex_gcconnex_1 php install/cli/docker_installer.php
 
 ### Docker specific configuration
 
@@ -105,9 +100,8 @@ utilisez `docker-compose` pour démarrer et/ou créer vos conteneurs Docker.
 
     docker-compose up
 
-Ensuite, visitez [http://localhost:8080](http://localhost:8080) et suivre les
-instructions pour compléter votre installation.  Une fois complet, regarder à
-[INSTALL.md](INSTALL.md#configure-plugins) et suivez les étapes additionnels.
+et ajouter un ligne ```<host ip> gcconnex.local``` a votre ficher "hosts".
+Ensuite, visitez [http://gcconnex.local](http://gcconnex.local).
 
 ### Configuration spécifique avec Docker
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - .:/var/www/html
       - ./data/data:/data
       - /var/www/html/vendor
+      - /var/www/html/docker
     depends_on:
       - gcconnex-db
       # - nginx-proxy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,9 +25,9 @@ services:
   gcconnex:
     build: .
     ports:
-      - 8080:80
+      - 80:80
     volumes:
-      - ./mod:/var/www/html/mod
+      - .:/var/www/html
       - ./data/data:/data
       - /var/www/html/vendor
     depends_on:
@@ -38,7 +38,7 @@ services:
       - DOCKER=1
       - HOME=/var/www/html
       - DBHOST=gcconnex-db
-      - WWWROOT=http://localhost:8080/
+      - WWWROOT=http://gcconnex.local/
 
   # ###########################################################################
   # The GCConnex cron container.  This container is responsible for executing

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# automated install
+php /var/www/html/install/cli/docker_installer.php
+
+# Start server - depending on the image, one of these will work
+echo "Starting server"
+$@

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # automated install
-php /var/www/html/install/cli/docker_installer.php
+php5 /var/www/html/install/cli/docker_installer.php
 
 # Start server - depending on the image, one of these will work
 echo "Starting server"

--- a/install/cli/docker_installer.php
+++ b/install/cli/docker_installer.php
@@ -58,6 +58,20 @@ $params = array(
 	'password' => 'adminpassword',
 );
 
+// wait for db to be ready
+echo "Connecting to database..";
+$etmp = error_reporting(E_ERROR);     // don't need all the connection errors...
+
+do{
+  echo ".";
+  sleep(1); // wait for the db container
+  $dbconnect = mysqli_connect($dbhost, $params['dbuser'], $params['dbpassword']);
+}while(!$dbconnect);
+
+echo "Connected!";
+mysqli_close($dbconnect);
+error_reporting($etmp);     // revert error reporting to default
+
 // install and create the .htaccess file
 $installer->batchInstall($params, TRUE);
 

--- a/install/cli/docker_installer.php
+++ b/install/cli/docker_installer.php
@@ -8,7 +8,7 @@
 $enabled = getenv('DOCKER') != ''; //are we in a Docker container?
 
 if (!$enabled) {
-	echo "This script should be run only in a Docker container environment.\n";
+	echo "This script should be run only in a properly configured Docker container environment.\n";
 	exit(1);
 }
 


### PR DESCRIPTION
New, easier way to set up a dev environment:
clone the repo, (when testing this, before it's merged you will need to run git checkout docker_automation)
run
```
docker-compose up
```
add an entry into your hosts file for
```
<host ip> gcconnex.local
```

and you now have a fully installed instance of the wiki (visual editor service extra, needs at bit more work) that you can reach at gcconnex.local! 

closes #1720 