### PR TITLE
Group Bookmarks API - Target get_entity

### DIFF
--- a/mod/gc_mobile_api/models/bookmark.php
+++ b/mod/gc_mobile_api/models/bookmark.php
@@ -249,7 +249,7 @@ function get_bookmarks_by_owner($user, $limit, $offset, $filters, $lang, $target
   }
   $target_entity = $user_entity;
   if ($target != ''){
-    $target_entity = is_numeric($target) ? get_user($target) : (strpos($target, '@') !== false ? get_user_by_email($target)[0] : get_user_by_username($target));
+    $target_entity = get_entity($target);
   }
 
   //add conditional for target later


### PR DESCRIPTION
Switching target to get_entity instead of user conditional. Allows group bookmarks based on target guid being passed.