### PR TITLE
Discussion API - Remove Cleaning Text

### DIFF
--- a/mod/gc_mobile_api/models/discussion.php
+++ b/mod/gc_mobile_api/models/discussion.php
@@ -81,7 +81,7 @@ function get_discussion($user, $guid, $thread, $lang)
 	$discussion->liked = count($liked) > 0;
 
 	$discussion->userDetails = get_user_block($discussion->owner_guid, $lang);
-	$discussion->description = clean_text(gc_explode_translation($discussion->description, $lang));
+	$discussion->description = gc_explode_translation($discussion->description, $lang);
 
 	$discussionsArray = array();
 	$discussionsArray[] = $discussion;
@@ -169,7 +169,7 @@ function get_discussions($user, $limit, $offset, $filters, $lang)
 		$discussion->liked = count($liked) > 0;
 
 		$discussion->userDetails = get_user_block($discussion->owner_guid, $lang);
-		$discussion->description = clean_text(gc_explode_translation($discussion->description, $lang));
+		$discussion->description = gc_explode_translation($discussion->description, $lang);
 	}
 
 	return $discussions;


### PR DESCRIPTION
Description for discussions is giving plain text, without any formatting. This fixes it so it shows basic formatting.
_______
**Formatting working on app:**
![discussion](https://user-images.githubusercontent.com/34379222/37542692-77e60de2-2935-11e8-9753-39e70cf43cf6.PNG)
_______
**Javascript is still handled fine without the clean:**
![discussionjs](https://user-images.githubusercontent.com/34379222/37542694-77f98872-2935-11e8-87b8-fbe150be9e63.PNG)
