### PR TITLE
(bug) fixed file_tools folder access display

### DIFF
--- a/mod/file_tools/views/default/forms/file_tools/folder/edit.php
+++ b/mod/file_tools/views/default/forms/file_tools/folder/edit.php
@@ -63,7 +63,7 @@ elgg_set_context("file_tools");
 $form_data .= "<div>";
 $form_data .= "<label>" . elgg_echo("access") . "</label>";
 $form_data .= "<br />";
-$form_data .= elgg_view("input/access", array("name" => "access_id", "value" => $access_id));
+$form_data .= elgg_view("input/access", array("name" => "access_id", "value" => $access_id, 'entity' => $folder));
 $form_data .= "</div>";
 
 // restore context

--- a/mod/wet4/views/default/forms/file_tools/folder/edit.php
+++ b/mod/wet4/views/default/forms/file_tools/folder/edit.php
@@ -106,7 +106,7 @@ elgg_set_context("file_tools");
 $form_data .= "<div>";
 $form_data .= "<label for='access_id'>" . elgg_echo("access") . "</label>";
 $form_data .= "<br />";
-$form_data .= elgg_view("input/access", array("name" => "access_id", "id" => "access_id", "value" => $access_id));
+$form_data .= elgg_view("input/access", array("name" => "access_id", "id" => "access_id", "value" => $access_id, 'entity' => $folder));
 $form_data .= "</div>";
 
 // restore context


### PR DESCRIPTION
Folder edit screen will now display the correct current access level

same as in #909
fixes #1765 