### PR TITLE
Mobile API: Wire Images + Wire API Refactor

### DIFF
--- a/mod/gc_mobile_api/models/wire.php
+++ b/mod/gc_mobile_api/models/wire.php
@@ -109,99 +109,22 @@ elgg_ws_expose_function(
 	false
 );
 
-function get_wirepost($user, $guid, $thread, $lang)
+function wires_foreach($wire_posts, $user_entity)
 {
-	$user_entity = is_numeric($user) ? get_user($user) : (strpos($user, '@') !== false ? get_user_by_email($user)[0] : get_user_by_username($user));
-	if (!$user_entity) {
-		return "User was not found. Please try a different GUID, username, or email address";
-	}
-	if (!$user_entity instanceof ElggUser) {
-		return "Invalid user. Please try a different GUID, username, or email address";
-	}
-
-	$entity = get_entity($guid);
-	if (!$entity) {
-		return "Wire was not found. Please try a different GUID";
-	}
-	if (!$entity instanceof ElggWire) {
-		return "Invalid wire. Please try a different GUID";
-	}
-
-	$thread_id = $entity->wire_thread;
-
-	if (!elgg_is_logged_in()) {
-		login($user_entity);
-	}
-
-	if ($thread) {
-		$all_wire_posts = elgg_list_entities_from_metadata(array(
-			"metadata_name" => "wire_thread",
-			"metadata_value" => $thread_id,
-			"type" => "object",
-			"subtype" => "thewire",
-			"limit" => 0,
-			"preload_owners" => true
-		));
-		$wire_posts = json_decode($all_wire_posts);
-
-		foreach ($wire_posts as $wire_post) {
-			$wire_post_obj = get_entity($wire_post->guid);
-			$reshare = $wire_post_obj->getEntitiesFromRelationship(array("relationship" => "reshare", "limit" => 1))[0];
-
-			$url = "";
-			if (!empty($reshare)) {
-				$url = $reshare->getURL();
-			}
-
-			$text = "";
-			if (!empty($reshare->title)) {
-				$text = $reshare->title;
-			} elseif (!empty($reshare->name)) {
-				$text = $reshare->name;
-			} elseif (!empty($reshare->description)) {
-				$text = elgg_get_excerpt($reshare->description, 140);
-			}
-
-			$wire_post->shareURL = $url;
-			$wire_post->shareText = gc_explode_translation($text, $lang);
-
-			$likes = elgg_get_annotations(array(
-				'guid' => $wire_post->guid,
-				'annotation_name' => 'likes'
-			));
-			$wire_post->likes = count($likes);
-
-			$liked = elgg_get_annotations(array(
-				'guid' => $wire_post->guid,
-				'annotation_owner_guid' => $user_entity->guid,
-				'annotation_name' => 'likes'
-			));
-			$wire_post->liked = count($liked) > 0;
-
-			$replied = elgg_get_entities_from_metadata(array(
-				"metadata_name" => "wire_thread",
-				"metadata_value" => $thread_id,
-				"type" => "object",
-				"subtype" => "thewire",
-				"owner_guid" => $user_entity->guid
-			));
-			$wire_post->replied = count($replied) > 0;
-
-			$wire_post->thread_id = $thread_id;
-
-			$wire_post->userDetails = get_user_block($wire_post->owner_guid, $lang);
-			$wire_post->description = wire_filter($wire_post->description);
-		}
-	} else {
-		$wire_posts = elgg_list_entities(array(
-			"type" => "object",
-			"subtype" => "thewire",
-			"guid" => $guid
-		));
-		$wire_post = json_decode($wire_posts)[0];
-
+	foreach ($wire_posts as $wire_post) {
 		$wire_post_obj = get_entity($wire_post->guid);
 		$reshare = $wire_post_obj->getEntitiesFromRelationship(array("relationship" => "reshare", "limit" => 1))[0];
+		$wire_attachements = elgg_get_entities_from_relationship(array(
+			'relationship' => 'is_attachment',
+			'relationship_guid' => $wire_post->guid,
+			'inverse_relationship' => true,
+			'limit' => 1
+		));
+
+		if ($wire_attachements){
+			$wire_post->attachment->guid = $wire_attachements[0]->getGUID();
+			$wire_post->attachment->name = $wire_attachements[0]->original_filename;
+		}
 
 		$url = "";
 		if (!empty($reshare)) {
@@ -235,19 +158,68 @@ function get_wirepost($user, $guid, $thread, $lang)
 
 		$replied = elgg_get_entities_from_metadata(array(
 			"metadata_name" => "wire_thread",
-			"metadata_value" => $thread_id,
+			"metadata_value" => $wire_post->wire_thread,
 			"type" => "object",
 			"subtype" => "thewire",
 			"owner_guid" => $user_entity->guid
 		));
 		$wire_post->replied = count($replied) > 0;
 
-		$wire_post->thread_id = $thread_id;
-
 		$wire_post->userDetails = get_user_block($wire_post->owner_guid, $lang);
 		$wire_post->description = wire_filter($wire_post->description);
+	}
 
-		$wire_posts = $wire_post;
+	return $wire_posts;
+}
+
+function get_wirepost($user, $guid, $thread, $lang)
+{
+	$user_entity = is_numeric($user) ? get_user($user) : (strpos($user, '@') !== false ? get_user_by_email($user)[0] : get_user_by_username($user));
+	if (!$user_entity) {
+		return "User was not found. Please try a different GUID, username, or email address";
+	}
+	if (!$user_entity instanceof ElggUser) {
+		return "Invalid user. Please try a different GUID, username, or email address";
+	}
+
+
+	$entity = get_entity($guid);
+	if (!$entity) {
+		return "Wire was not found. Please try a different GUID";
+	}
+	if (!$entity instanceof ElggWire) {
+		return "Invalid wire. Please try a different GUID";
+	}
+
+	if (!elgg_is_logged_in()) {
+		login($user_entity);
+	}
+
+	$thread_id = $entity->wire_thread;
+
+	if ($thread) {
+		$all_wire_posts = elgg_list_entities_from_metadata(array(
+			"metadata_name" => "wire_thread",
+			"metadata_value" => $thread_id,
+			"type" => "object",
+			"subtype" => "thewire",
+			"limit" => 0,
+			"preload_owners" => true
+		));
+		$wire_posts = json_decode($all_wire_posts);
+
+		$wire_posts = wires_foreach($wire_posts, $user_entity);
+
+	} else {
+		$wire_posts = elgg_list_entities(array(
+			"type" => "object",
+			"subtype" => "thewire",
+			"guid" => $guid
+		));
+
+		$wire_post = json_decode($wire_posts)[0];
+
+		$wire_posts = wires_foreach($wire_posts, $user_entity);
 	}
 
 	return $wire_posts;
@@ -292,52 +264,7 @@ function get_wireposts($user, $limit, $offset, $filters, $lang)
 
 	$wire_posts = json_decode($all_wire_posts);
 
-	foreach ($wire_posts as $wire_post) {
-		$wire_post_obj = get_entity($wire_post->guid);
-		$reshare = $wire_post_obj->getEntitiesFromRelationship(array("relationship" => "reshare", "limit" => 1))[0];
-
-		$url = "";
-		if (!empty($reshare)) {
-			$url = $reshare->getURL();
-		}
-
-		$text = "";
-		if (!empty($reshare->title)) {
-			$text = $reshare->title;
-		} elseif (!empty($reshare->name)) {
-			$text = $reshare->name;
-		} elseif (!empty($reshare->description)) {
-			$text = elgg_get_excerpt($reshare->description, 140);
-		}
-
-		$wire_post->shareURL = $url;
-		$wire_post->shareText = gc_explode_translation($text, $lang);
-
-		$likes = elgg_get_annotations(array(
-			'guid' => $wire_post->guid,
-			'annotation_name' => 'likes'
-		));
-		$wire_post->likes = count($likes);
-
-		$liked = elgg_get_annotations(array(
-			'guid' => $wire_post->guid,
-			'annotation_owner_guid' => $user_entity->guid,
-			'annotation_name' => 'likes'
-		));
-		$wire_post->liked = count($liked) > 0;
-
-		$replied = elgg_get_entities_from_metadata(array(
-			"metadata_name" => "wire_thread",
-			"metadata_value" => $wire_post->wire_thread,
-			"type" => "object",
-			"subtype" => "thewire",
-			"owner_guid" => $user_entity->guid
-		));
-		$wire_post->replied = count($replied) > 0;
-
-		$wire_post->userDetails = get_user_block($wire_post->owner_guid, $lang);
-		$wire_post->description = wire_filter($wire_post->description);
-	}
+	$wire_posts = wires_foreach($wire_posts, $user_entity);
 
 	return $wire_posts;
 }
@@ -367,53 +294,7 @@ function get_wirepostsbycolleagues($user, $limit, $offset, $lang)
 	));
 	$wire_posts = json_decode($all_wire_posts);
 
-	foreach ($wire_posts as $wire_post) {
-		$wire_post_obj = get_entity($wire_post->guid);
-
-		$reshare = $wire_post_obj->getEntitiesFromRelationship(array("relationship" => "reshare", "limit" => 1))[0];
-
-		$url = "";
-		if (!empty($reshare)) {
-			$url = $reshare->getURL();
-		}
-
-		$text = "";
-		if (!empty($reshare->title)) {
-			$text = $reshare->title;
-		} elseif (!empty($reshare->name)) {
-			$text = $reshare->name;
-		} elseif (!empty($reshare->description)) {
-			$text = elgg_get_excerpt($reshare->description, 140);
-		}
-
-		$wire_post->shareURL = $url;
-		$wire_post->shareText = gc_explode_translation($text, $lang);
-
-		$likes = elgg_get_annotations(array(
-			'guid' => $wire_post->guid,
-			'annotation_name' => 'likes'
-		));
-		$wire_post->likes = count($likes);
-
-		$liked = elgg_get_annotations(array(
-			'guid' => $wire_post->guid,
-			'annotation_owner_guid' => $user_entity->guid,
-			'annotation_name' => 'likes'
-		));
-		$wire_post->liked = count($liked) > 0;
-
-		$replied = elgg_get_entities_from_metadata(array(
-			"metadata_name" => "wire_thread",
-			"metadata_value" => $wire_post->wire_thread,
-			"type" => "object",
-			"subtype" => "thewire",
-			'owner_guid' => $user_entity->guid
-		));
-		$wire_post->replied = count($replied) > 0;
-
-		$wire_post->userDetails = get_user_block($wire_post->owner_guid, $lang);
-		$wire_post->description = wire_filter($wire_post->description);
-	}
+	$wire_posts = wires_foreach($wire_posts, $user_entity);
 
 	return $wire_posts;
 }
@@ -449,52 +330,7 @@ function get_wirepostsbyuser($profileemail, $user, $limit, $offset, $lang)
 	));
 	$wire_posts = json_decode($all_wire_posts);
 
-	foreach ($wire_posts as $wire_post) {
-		$wire_post_obj = get_entity($wire_post->guid);
-		$reshare = $wire_post_obj->getEntitiesFromRelationship(array("relationship" => "reshare", "limit" => 1))[0];
-
-		$url = "";
-		if (!empty($reshare)) {
-			$url = $reshare->getURL();
-		}
-
-		$text = "";
-		if (!empty($reshare->title)) {
-			$text = $reshare->title;
-		} elseif (!empty($reshare->name)) {
-			$text = $reshare->name;
-		} elseif (!empty($reshare->description)) {
-			$text = elgg_get_excerpt($reshare->description, 140);
-		}
-
-		$wire_post->shareURL = $url;
-		$wire_post->shareText = gc_explode_translation($text, $lang);
-
-		$likes = elgg_get_annotations(array(
-			'guid' => $wire_post->guid,
-			'annotation_name' => 'likes'
-		));
-		$wire_post->likes = count($likes);
-
-		$liked = elgg_get_annotations(array(
-			'guid' => $wire_post->guid,
-			'annotation_owner_guid' => $viewer->guid,
-			'annotation_name' => 'likes'
-		));
-		$wire_post->liked = count($liked) > 0;
-
-		$replied = elgg_get_entities_from_metadata(array(
-			"metadata_name" => "wire_thread",
-			"metadata_value" => $wire_post->wire_thread,
-			"type" => "object",
-			"subtype" => "thewire",
-			"owner_guid" => $viewer->guid
-		));
-		$wire_post->replied = count($replied) > 0;
-
-		$wire_post->userDetails = get_user_block($wire_post->owner_guid, $lang);
-		$wire_post->description = wire_filter($wire_post->description);
-	}
+	$wire_posts = wires_foreach($wire_posts, $user_entity);
 
 	return $wire_posts;
 }


### PR DESCRIPTION
`function wires_foreach($wire_posts, $user_entity)` handles the wire variables, as they are the same for each api that deals with existing wire entities. 

Added wire images to `get_wirepost` `get_wireposts` `function get_wirepostsbycolleagues` and `function get_wirepostsbyuser`, and moved the foreach to using `wires_foreach()`

_______

Already on gccollab repo + on gccollab prod, gccollab repo has separate commits if you are interested in the process.