### PR TITLE
MobileAPI - Edit Blogs

### DIFF
--- a/mod/gc_mobile_api/models/blog.php
+++ b/mod/gc_mobile_api/models/blog.php
@@ -404,7 +404,7 @@ function get_blog_edit($user, $guid, $lang)
  return $blog_post;
 }
 
-function save_blog($user, $title, $excerpt, $body, $container_guid, $comments, $access, $status, $lang)
+function save_blog($user, $title, $excerpt, $body, $container_guid, $blog_guid, $comments, $access, $status, $lang)
 {
  $user_entity = is_numeric($user) ? get_user($user) : (strpos($user, '@') !== false ? get_user_by_email($user)[0] : get_user_by_username($user));
 	 if (!$user_entity) {

--- a/mod/gc_mobile_api/models/discussion.php
+++ b/mod/gc_mobile_api/models/discussion.php
@@ -244,8 +244,6 @@ function get_discussion_edit($user, $guid, $lang)
 
  $discussion->title = json_decode($discussion->title);
  $discussion->description = json_decode($discussion->description);
- //access id?
- //status?
  $container = get_entity($discussion->container_guid);
  $discussion->group->public = $container->isPublicMembership();
  if (!$discussion->group->public && !$container->isMember($user_entity)){


### PR DESCRIPTION
**Get_Blog_Edit**  
Grabs a a blog post based on user id and blog post id, with only info needed for edit form

**save.blog replace post.blog**
Replaced post.blog with save.blog, which is the same but with a bit of extra handling to allow Save and Edit inside one function.
Adds conditional for grabbing existing blog or creating new blog.
Extra variables relating to holding revision information.
Takes extra input: blog_guid for editing that entity.