### PR TITLE
cookie for language toggle

### DIFF
--- a/mod/gc_lang_url_handler/start.php
+++ b/mod/gc_lang_url_handler/start.php
@@ -25,6 +25,9 @@ function global_url_handler($hook, $type, $returnvalue, $params) {
 	$site_url = preg_replace("(^https?://)", "", $site_url);
 	$site_url = explode("/", $site_url);
 
+	$cookie_language = $_COOKIE['lang'];
+	$url_language = $_GET['language'];
+
 	if (preg_match("/localhost|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/", $site_url[0])) {
 		$domain = $site_url[0];
 	}
@@ -36,31 +39,39 @@ function global_url_handler($hook, $type, $returnvalue, $params) {
 		
 		if (strpos($_SERVER['REQUEST_URI'], '/comment/view/') === false && strpos($_SERVER['REQUEST_URI'], '/view') !== false || strpos($_SERVER['REQUEST_URI'], '/profile') !== false) {
 
-			if ($_GET["language"] == 'fr') { 
-				if ($_COOKIE['lang'] != 'fr') {
-					setcookie('lang', 'fr', 0, '/', $domain);
-				}
-			} elseif ($_GET["language"] == 'en') {
-				if ($_COOKIE['lang'] != 'en') {
-					setcookie('lang', 'en', 0, '/', $domain);
-				}
-			} else {
-				
-				if ($_GET["language"] == '' || $_GET["language"] != 'en' || $_GET["language"] != 'fr')
-					forward("?language=" . get_current_language());
 
+			// if url is set to french, then set cookie to french
+			if ($url_language == 'fr') { 
+				setcookie('lang', $url_language, 0, '/', $domain);
+			} 
 
+			// if url is set to english, then set cookie to english
+			if ($url_language == 'en') {
+				setcookie('lang', $url_language, 0, '/', $domain);
+			} 
+			
+			// if nothing is set in the url, then set url param based on the cookie selection
+			if ($url_language == '') {
+				// if both url param and cookie are not set then set them based on user settings
+				if ($cookie_language == '') {
+					setcookie('lang', get_current_language(), 0, '/', $domain);
+					forward("?language=".get_current_language());
+
+				// if only the url parameter is not set, then set using the cookie language
+				} else {
+					forward("?language=" . $cookie_language);
+				}
+				return true;
 			}
 
-			// make sure both cookie and url param match			
-			if ($url_language !== $cookie_language) {
-				forward("?language={$url_language}");
+
+			// once the cookie has been set, just refresh the page so that elgg picks up on cookie changes
+			if ($url_language !== $cookie_language)  {
+				forward("?language=" . $url_language);
 			}
 
-		} else {
-
-			return;
 		}
+
 	}
 }
 

--- a/mod/gc_lang_url_handler/start.php
+++ b/mod/gc_lang_url_handler/start.php
@@ -21,6 +21,14 @@ function global_url_handler($hook, $type, $returnvalue, $params) {
 	$clean_domain = str_replace(array('https://', 'http://', '/', 'www.'), '', elgg_get_site_url());
 	$domain = '.' . $clean_domain;
 
+	$site_url = elgg_get_site_url();
+	$site_url = preg_replace("(^https?://)", "", $site_url);
+	$site_url = explode("/", $site_url);
+
+	if (preg_match("/localhost|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/", $site_url[0])) {
+		$domain = $site_url[0];
+	}
+
 	// do not include the gsa crawler, this will be used for public and solr crawler
 	if (strstr(strtolower($_SERVER['HTTP_USER_AGENT']), 'gsa-crawler') === false) {
 		// checks to make sure that the url does not affect the ajax calls
@@ -37,10 +45,16 @@ function global_url_handler($hook, $type, $returnvalue, $params) {
 					setcookie('lang', 'en', 0, '/', $domain);
 				}
 			} else {
-				if ($_GET["language"] == '' || $_GET["language"] != 'en' || $_GET["language"] != 'fr'  )  {
-					
+				
+				if ($_GET["language"] == '' || $_GET["language"] != 'en' || $_GET["language"] != 'fr')
 					forward("?language=" . get_current_language());
-				}
+
+
+			}
+
+			// make sure both cookie and url param match			
+			if ($url_language !== $cookie_language) {
+				forward("?language={$url_language}");
 			}
 
 		} else {

--- a/mod/gc_lang_url_handler/start.php
+++ b/mod/gc_lang_url_handler/start.php
@@ -54,8 +54,11 @@ function global_url_handler($hook, $type, $returnvalue, $params) {
 			if ($url_language == '') {
 				// if both url param and cookie are not set then set them based on user settings
 				if ($cookie_language == '') {
-					setcookie('lang', get_current_language(), 0, '/', $domain);
-					forward("?language=".get_current_language());
+					$current_language = get_current_language();
+					if ($current_language == '') $current_language = 'en';
+					
+					setcookie('lang', $current_language, 0, '/', $domain);
+					forward("?language=".$current_language);
 
 				// if only the url parameter is not set, then set using the cookie language
 				} else {

--- a/mod/gc_splash_page/pages/splash.php
+++ b/mod/gc_splash_page/pages/splash.php
@@ -22,12 +22,12 @@ $domain = '.' . $clean_domain;
 $securitytoken = elgg_view('input/securitytoken');
 
 // PLEASE CHANGE IF THIS DOES NOT WORK ON YOUR LOCALHOST
-$site_url = elgg_get_site_url();
-$site_url = preg_replace("(^https?://)", "", $site_url);
-$site_url = explode("/", $site_url);
+$get_site_url = elgg_get_site_url();
+$get_site_url = preg_replace("(^https?://)", "", $get_site_url);
+$get_site_url = explode("/", $get_site_url);
 
-if (preg_match("/localhost|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/", $site_url[0])) {
-	$domain = $site_url[0];
+if (preg_match("/localhost|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/", $get_site_url[0])) {
+	$domain = $get_site_url[0];
 }
 
 $cookie_name = "lang";

--- a/mod/toggle_language/views/default/toggle_language/toggle_lang.php
+++ b/mod/toggle_language/views/default/toggle_language/toggle_lang.php
@@ -3,6 +3,16 @@
 		global $SESSION;
 		$clean_domain = str_replace(array('https://', 'http://', '/', 'www.'), '', elgg_get_site_url());
 		$domain ='.' . $clean_domain;
+
+		// PLEASE CHANGE IF THIS DOES NOT WORK ON YOUR LOCALHOST
+		$site_url = elgg_get_site_url();
+		$site_url = preg_replace("(^https?://)", "", $site_url);
+		$site_url = explode("/", $site_url);
+
+		if (preg_match("/localhost|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/", $site_url[0])) {
+			$domain = $site_url[0];
+		}
+
 		$cookie_name = "lang";
 	?>
 


### PR DESCRIPTION
the domain for the cookie would not work with local instances (site url would be localhost, or local network ip address with gcconnex as the directory), it will display javascript error in the developer's tool (require.js for translations)

@Troy-Lawson what else was not working with the language param in the url or is that already patched?