### PR TITLE
Colleague connection autocomplete

### DIFF
--- a/mod/group_tools/procedures/group_invite_autocomplete.php
+++ b/mod/group_tools/procedures/group_invite_autocomplete.php
@@ -33,14 +33,25 @@ if (!empty($user) && !empty($q) && !empty($group_guid)) {
 	if ($relationship != "email") {
 		$dbprefix = elgg_get_config("dbprefix");
 		
-		// find existing users
-		$query_options = array(
-			"type" => "user",
-			"limit" => $limit,
-			"joins" => array("JOIN {$dbprefix}users_entity u ON e.guid = u.guid"),
-			"wheres" => array("(u.name LIKE '%{$q}%' OR u.username LIKE '%{$q}%')", "u.banned = 'no'"),
-			"order_by" => "u.name asc"
-		);
+		if( is_numeric($q) ){
+			// find existing users
+			$query_options = array(
+				"type" => "user",
+				"limit" => $limit,
+				"joins" => array("JOIN {$dbprefix}users_entity u ON e.guid = u.guid"),
+				"wheres" => array("u.guid = {$q}", "u.banned = 'no'"),
+				"order_by" => "u.name asc"
+			);
+		} else {
+			// find existing users
+			$query_options = array(
+				"type" => "user",
+				"limit" => $limit,
+				"joins" => array("JOIN {$dbprefix}users_entity u ON e.guid = u.guid"),
+				"wheres" => array("(u.name LIKE '%{$q}%' OR u.username LIKE '%{$q}%')", "u.banned = 'no'"),
+				"order_by" => "u.name asc"
+			);
+		}
 		
 		if (!$include_self) {
 			if (empty($current_users)) {

--- a/mod/wet4/pages/friends/collections/add.php
+++ b/mod/wet4/pages/friends/collections/add.php
@@ -11,9 +11,7 @@ elgg_gatekeeper();
 
 $title = elgg_echo('friends:collections:add');
 
-$content = elgg_view_form('friends/collections/add', array(), array(
-	'friends' => elgg_get_logged_in_user_entity()->getFriends(array('limit' => 0)),
-));
+$content = elgg_view_form('friends/collections/add');
 
 $body = elgg_view_layout('one_sidebar', array(
 	'title' => $title, 

--- a/mod/wet4/views/default/forms/friends/collections/add.php
+++ b/mod/wet4/views/default/forms/friends/collections/add.php
@@ -21,38 +21,18 @@ if (isset($vars['collection'])) {
 	$highlight = 'all';
 }
 
-echo "<div class=\"mtm\"><label for='collection_name'>" . elgg_echo("friends:collectionname") . "</label><br/>";
+echo "<div class='mbl'><label for='collection_name'>" . elgg_echo("friends:collectionname") . "</label>";
 echo elgg_view("input/text", array(
-		"name" => "collection_name",
-		"id" => "collection_name",
-		"value" => $title,
-    'required '=> "required",
-	));
-echo "</div>";
-
-echo "<div>";
-if ($vars['collection_members']) {
-	echo elgg_echo("friends:collectionfriends") . "<br />";
-	foreach ($vars['collection_members'] as $mem) {
-		echo elgg_view_entity_icon($mem, 'tiny');
-		echo $mem->name;
-	}
-}
-echo "</div>";
-
-$members = get_members_of_access_collection($vars['collection']->id, true);
-if (!$members) {
-	$members = array();
-}
-
-echo "<div><label for='friends_collection'>" . elgg_echo("friends:addfriends") . "</label>";
-echo elgg_view('input/friendspicker', array(
-	'entities' => $vars['friends'],
-	'name' => 'friends_collection',
-	'id' => 'friends_collection',
-	'highlight' => $highlight,
-    'value' => $members
+	"name" => "collection_name",
+	"id" => "collection_name",
+	"value" => $title,
+    "required" => "required"
 ));
+echo "</div>";
+
+echo "<div id='colleague_collection_invite_users' class='mbl'>";
+echo "<div><label for='colleague_collection_autocomplete'>" . elgg_echo("group_tools:group:invite:users:description") . "</label></div>";
+echo elgg_view("input/colleague_collection_autocomplete", array("name" => "friends_collection", "id" => "colleague_collection", "group_guid" => elgg_get_logged_in_user_guid(), "relationship" => "site"));
 echo "</div>";
 
 echo '<div class="elgg-foot">';
@@ -62,7 +42,7 @@ if (isset($vars['collection'])) {
 		'value' => $vars['collection']->id,
 	));
 }
-echo elgg_view('input/submit', array('name' => 'submit', 'value' => elgg_echo('save'), 'class' => 'btn btn-primary mrgn-tp-md'));
+echo elgg_view('input/submit', array('name' => 'submit', 'value' => elgg_echo('save'), 'class' => 'btn btn-primary'));
 echo '</div>';
 
 ?>

--- a/mod/wet4/views/default/forms/friends/collections/edit.php
+++ b/mod/wet4/views/default/forms/friends/collections/edit.php
@@ -21,23 +21,13 @@ if (isset($vars['collection'])) {
 	$highlight = 'all';
 }
 
-echo "<div class=\"mtm\"><label for='collection_name'>" . elgg_echo("friends:collectionname") . "</label><br/>";
+echo "<div class='mbl'><label for='collection_name'>" . elgg_echo("friends:collectionname") . "</label>";
 echo elgg_view("input/text", array(
-		"name" => "collection_name",
-		"id" => "collection_name",
-		"value" => $title,
-    'required '=> "required",
-	));
-echo "</div>";
-
-echo "<div>";
-if ($vars['collection_members']) {
-	echo elgg_echo("friends:collectionfriends") . "<br />";
-	foreach ($vars['collection_members'] as $mem) {
-		echo elgg_view_entity_icon($mem, 'tiny');
-		echo $mem->name;
-	}
-}
+	"name" => "collection_name",
+	"id" => "collection_name",
+	"value" => $title,
+    "required" => "required",
+));
 echo "</div>";
 
 $members = get_members_of_access_collection($vars['collection']->id, true);
@@ -45,16 +35,9 @@ if (!$members) {
 	$members = array();
 }
 
-echo "<div><label for='friends_collection'>" . elgg_echo("friends:addfriends") . "</label>";
-echo elgg_view('input/friendspicker', array(
-	'entities' => $vars['friends'],
-	'name' => 'friends_collection',
-	'id' => 'friends_collection',
-   	'value' => $members,
-	'highlight' => $highlight,
-    'collection_id' => $vars['collection']->id,
-	'formtarget' => $site_url . 'action/friends/collections/edit',
-));
+echo "<div id='colleague_collection_invite_users' class='mbl'>";
+echo "<div><label for='colleague_collection_autocomplete'>" . elgg_echo("group_tools:group:invite:users:description") . "</label></div>";
+echo elgg_view("input/colleague_collection_autocomplete", array("name" => "friends_collection", "id" => "colleague_collection", "group_guid" => elgg_get_logged_in_user_guid(), "relationship" => "site", "members" => $members));
 echo "</div>";
 
 echo '<div class="elgg-foot">';
@@ -64,5 +47,7 @@ if (isset($vars['collection'])) {
 		'value' => $vars['collection']->id,
 	));
 }
-//echo elgg_view('input/submit', array('name' => 'submit', 'value' => elgg_echo('save'), 'class' => 'btn btn-primary'));
+echo elgg_view('input/submit', array('name' => 'submit', 'value' => elgg_echo('save'), 'class' => 'btn btn-primary'));
 echo '</div>';
+
+?>

--- a/mod/wet4/views/default/input/colleague_collection_autocomplete.php
+++ b/mod/wet4/views/default/input/colleague_collection_autocomplete.php
@@ -100,7 +100,7 @@ if ($minChars < 1) {
 				};
 			});
 
-		if(members !== ''){
+		if(members !== '' && members !== 'null'){
 			$.each(JSON.parse(members), function(key, value) {
 				$.getJSON(elgg.get_site_url() + "groups/group_invite_autocomplete", {
 					q: value,

--- a/mod/wet4/views/default/input/colleague_collection_autocomplete.php
+++ b/mod/wet4/views/default/input/colleague_collection_autocomplete.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * special autocomplete input
+ */
+$name = elgg_extract("name", $vars); // input name of the selected user
+$backup = elgg_extract("backup_name", $vars); // input name of the selected user
+$id = elgg_extract("id", $vars);
+$relationship = elgg_extract("relationship", $vars);
+$members = elgg_extract("members", $vars);
+
+$destination = $id . "_autocomplete_results";
+
+$minChars = (int) elgg_extract("minChars", $vars, 3);
+if ($minChars < 1) {
+	$minChars = 3;
+}
+
+?>
+<input name="<?php echo $backup; ?>" type="text" id="<?php echo $id; ?>_autocomplete" class="elgg-input elgg-input-autocomplete" />
+
+<div id="<?php echo $destination; ?>" class="mtm clearfloat"></div>
+
+<script type="text/javascript">
+	$(document).ready(function() {
+		var members = '<?php echo json_encode($members); ?>';
+
+		$("#<?php echo $id; ?>_autocomplete").each(function() {
+			$(this)
+			// don't navigate away from the field on tab when selecting an item
+			.bind( "keydown", function(event) {
+				if (event.keyCode === $.ui.keyCode.TAB && $(this).data("autocomplete").menu.active) {
+					event.preventDefault();
+				}
+			})
+			.autocomplete({
+				source: function(request, response) {
+					$.getJSON(elgg.get_site_url() + "groups/group_invite_autocomplete", {
+						q: request.term,
+						'user_guids': function() {
+							var result = "";
+
+							$("#<?php echo $destination; ?> input[name='<?php echo $name; ?>[]']").each(function(index, elem) {
+								if (result == "") {
+									result = $(this).val();
+								} else {
+									result += "," + $(this).val();
+								}
+							});
+
+							return result;
+						},
+						'group_guid' : <?php echo $vars["group_guid"]; ?>
+						<?php
+						if (!empty($relationship)) {
+							echo ", 'relationship' : '" . $relationship . "'";
+						}
+						?>
+					}, response );
+				},
+				search: function() {
+					// custom minLength
+					var term = this.value;
+					if (term.length < <?php echo $minChars; ?>) {
+						return false;
+					}
+				},
+
+				select: function(event, ui) {
+					this.value = "";
+					var result = "";
+
+					result += "<div class='group_tools_group_invite_autocomplete_autocomplete_result elgg-discover_result elgg-discover'>";
+
+					if (ui.item.type == "user") {
+						result += "<input type='hidden' value='" + ui.item.value + "' name='<?php echo $name; ?>[]' />";
+					} else if (ui.item.type == "email") {
+						result += "<input type='hidden' value='" + ui.item.value + "' name='<?php echo $name; ?>_email[]' />";
+					}
+					result += ui.item.content;
+
+					result += "<?php echo addslashes('<i class="fa fa-trash-o fa-lg icon-unsel mrgn-lft-sm elgg-icon-delete-alt"><span class="wb-inv">' . elgg_echo('delete:this') . '</span></i>'); ?>";
+					result += "</div>";
+
+					$('#<?php echo $destination; ?>').append(result);
+					return false;
+				},
+				autoFocus: true,
+				messages: {
+			        noResults: '',
+			        results: function() {}
+			    }
+			}).data("ui-autocomplete")._renderItem = function(ul, item) {
+				var list_body = "";
+				list_body = item.content;
+
+					return $( "<li></li>" )
+					.data( "item.autocomplete", item )
+					.append("<a>" + list_body + " -  <?php echo elgg_echo('group:invite:clicktoadd') ?></a>")
+					.appendTo( ul );
+				};
+			});
+
+		if(members !== ''){
+			$.each(JSON.parse(members), function(key, value) {
+				$.getJSON(elgg.get_site_url() + "groups/group_invite_autocomplete", {
+					q: value,
+					'user_guids': function() {
+						var result = "";
+
+						$("#<?php echo $destination; ?> input[name='<?php echo $name; ?>[]']").each(function(index, elem) {
+							if (result == "") {
+								result = $(this).val();
+							} else {
+								result += "," + $(this).val();
+							}
+						});
+
+						return result;
+					},
+					'group_guid' : <?php echo $vars["group_guid"]; ?>
+					<?php
+					if (!empty($relationship)) {
+						echo ", 'relationship' : '" . $relationship . "'";
+					}
+					?>
+				}).success(function(item) {
+					var result = "";
+
+					result += "<div class='group_tools_group_invite_autocomplete_autocomplete_result elgg-discover_result elgg-discover'>";
+
+					if (item[0].type == "user") {
+						result += "<input type='hidden' value='" + item[0].value + "' name='<?php echo $name; ?>[]' />";
+					} else if (item[0].type == "email") {
+						result += "<input type='hidden' value='" + item[0].value + "' name='<?php echo $name; ?>_email[]' />";
+					}
+					result += item[0].content;
+
+					result += "<?php echo addslashes('<i class="fa fa-trash-o fa-lg icon-unsel mrgn-lft-sm elgg-icon-delete-alt"><span class="wb-inv">' . elgg_echo('delete:this') . '</span></i>'); ?>";
+					result += "</div>";
+
+					$('#<?php echo $destination; ?>').append(result);
+				});
+			});
+		}
+
+		$('#<?php echo $destination; ?> .elgg-icon-delete-alt').live("click", function() {
+			$(this).parent('div').remove();
+		});
+	});
+
+</script>


### PR DESCRIPTION
Addresses issue https://github.com/gctools-outilsgc/gccollab/issues/313 - changes the DataTable when creating a new "Colleague collection" to an autocomplete text field.

This was done to prevent Fatal errors from appearing for users with large numbers of colleagues. Example can be seen here: https://dev.gccollab.ca/collections/owner/