### PR TITLE
Adding group operators fix

### DIFF
--- a/mod/wet4/languages/en.php
+++ b/mod/wet4/languages/en.php
@@ -4,6 +4,7 @@ $site_url = elgg_get_site_url();
 return array(
 
     'thewire:head:title' => 'Wire post',
+    'group_operator:find:user:error' => "Could not find user",
 
     /*
     More context links - entity/river menus

--- a/mod/wet4/languages/fr.php
+++ b/mod/wet4/languages/fr.php
@@ -4,6 +4,7 @@
 return array(
 
 	'thewire:head:title' => 'Message sur le fil',
+	'group_operator:find:user:error' => "Impossible de trouver l'utilisateur",
 
 	'entity:like:link:page_top' => 'Aimer la page "%s"',
 	'entity:unlike:link:page_top' => 'Enlever la mention j\'aime de la page "%s"',

--- a/mod/wet4/views/default/forms/group_operators/add.php
+++ b/mod/wet4/views/default/forms/group_operators/add.php
@@ -12,12 +12,11 @@
 $group_guid = elgg_extract('entity', $vars)->guid;
 //$candidates = elgg_extract('candidates', $vars);
 
-//if(!empty($candidates)){
-	$body .= '<label for="who">'.elgg_echo('group_operators:new').'</label><br />';
-	//$body .= elgg_view('input/combobox', array('name'=>'who','id'=>'who', 'options_values'=>group_operators_prepare_combo_vars($candidates),
-	//						'style'=>'display:inline; width:80%', 'title'=>elgg_echo('group_operators:new:instructions')));
+	$body .= '<label for="groups-owner-guid">'.elgg_echo('group_operators:new').'</label><br />';
+
 	$body .= elgg_view("input/text", array(
 				"id" => "groups-owner-guid",
+				"name" => "groups-owner-guid",
 				"value" =>  '',
 			));
 
@@ -39,7 +38,12 @@ $group_guid = elgg_extract('entity', $vars)->guid;
 	$body .= elgg_view('input/submit',array('value'=>elgg_echo('group_operators:new:button'), 'class' => 'btn btn-primary mrgn-tp-md'));
 	$body .= '<div class="elgg-footer">'.elgg_view('input/hidden', array('name'=>'mygroup', 'value'=>$group_guid)).'</div>';
 	echo $body;
-//}
+
 
 
 ?>
+<style>
+.panel-body {
+	padding: 1px 0;
+}
+</style>


### PR DESCRIPTION
Added additional checks to the add operator action. Now instead of just waiting for the select field to be populated with a user's guid, the action reads the text input to see what the user entered and tries to find a user based on that.

Also improved messaging to user, used to give "You do not have the permissions for this" no matter the problem. Now will tell user that the targeted cannot be found.

Ways to test:
  1. Add operator as expected
  2. Type in user's username
  3. Type in user's displayname

Closes gctools-outilsgc/gccollab#345