### PR TITLE
Mobile API: Get_Groups - Description, Access, Clean_Text

### DIFF
--- a/mod/gc_mobile_api/models/group.php
+++ b/mod/gc_mobile_api/models/group.php
@@ -375,6 +375,12 @@ function get_groups($user, $limit, $offset, $filters, $lang)
 
 		$groupObj = get_entity($group->guid);
 		$group->member = $groupObj->isMember($user_entity);
+		$group->public = $groupObj->isPublicMembership();
+		if (!$group->public && !$group->member){
+			$group->access = false;
+		} else {
+			$group->access = true;
+		}
 		$group->owner = ($groupObj->getOwnerEntity() == $user_entity);
 		$group->iconURL = $groupObj->geticon();
 		$group->count = $groupObj->getMembers(array('count' => true));
@@ -383,7 +389,12 @@ function get_groups($user, $limit, $offset, $filters, $lang)
 		$group->tags = $groupObj->interests;
 
 		$group->userDetails = get_user_block($group->owner_guid, $lang);
-		$group->description = gc_explode_translation($group->description, $lang);
+		if ($group->access){
+			$group->description = clean_text(gc_explode_translation($group->description, $lang));
+			$group->description = substr($group->description, 0, 250);
+		} else {
+			$group->description = elgg_echo("groups:access:private", $lang);
+		}
 	}
 
 	return $groups;
@@ -593,7 +604,7 @@ function get_group_discussions($user, $guid, $limit, $offset, $lang)
 
 	$discussions = json_decode($discussions);
 	foreach ($discussions as $discussion) {
-		
+
 		$discussion->userDetails = get_user_block($discussion->owner_guid, $lang);
 		$discussion->title = gc_explode_translation($discussion->title, $lang);
 		$discussion->description = gc_explode_translation($discussion->description, $lang);


### PR DESCRIPTION
As used in get_group, get_groups now checks if group is public or if user is a member. If no to both, will set description to access:private message. [mobile_issue: 264](https://github.com/gctools-outilsgc/gccollab-mobile/issues/264)

Clean text for description variable, for group lists. Same as usergroups is handled.
Truncated the description, as full description is not needed for group lists.
[mobile_issue: 320](https://github.com/gctools-outilsgc/gccollab-mobile/issues/320)

