### PR TITLE
Mobile Events API: Offsets, Target, Now To Future

### DIFF
--- a/mod/gc_mobile_api/models/event.php
+++ b/mod/gc_mobile_api/models/event.php
@@ -53,6 +53,7 @@ elgg_ws_expose_function(
 	"get_events_by_owner",
 	array(
 		"user" => array('type' => 'string', 'required' => true),
+		"target" => array('type' => 'string', 'required' => false, 'default' => ""),
 		"from" => array('type' => 'string', 'required' => false, 'default' => ""),
 		"to" => array('type' => 'string', 'required' => false, 'default' => ""),
 		"limit" => array('type' => 'int', 'required' => false, 'default' => 10),
@@ -296,7 +297,7 @@ function get_events($user, $from, $to, $limit, $offset, $lang)
 	return $events;
 }
 
-function get_events_by_owner($user, $from, $to, $limit, $offset, $lang)
+function get_events_by_owner($user, $target, $from, $to, $limit, $offset, $lang)
 {
 	$user_entity = is_numeric($user) ? get_user($user) : (strpos($user, '@') !== false ? get_user_by_email($user)[0] : get_user_by_username($user));
 	if (!$user_entity) {
@@ -305,9 +306,12 @@ function get_events_by_owner($user, $from, $to, $limit, $offset, $lang)
 	if (!$user_entity instanceof ElggUser) {
 		return "Invalid user. Please try a different GUID, username, or email address";
 	}
-
 	if (!elgg_is_logged_in()) {
 		login($user_entity);
+	}
+	$target_entity = $user_entity;
+	if ($target != ''){
+		$target_entity = get_entity($target);
 	}
 
 	$params = array(
@@ -316,9 +320,7 @@ function get_events_by_owner($user, $from, $to, $limit, $offset, $lang)
 		'limit' => $limit,
 		'offset' => $offset,
 		'order_by_metadata' => array(array('name' => 'start_date', 'direction' => 'ASC', 'as' => 'integer')),
-		'filter' => 'mine',
-		'relationship' => 'personal_event',
-		'relationship_guid' => $user_entity->entity,
+		'container_guid' => $target_entity->guid,
 	);
 
 	$now = time();

--- a/mod/gc_mobile_api/models/event.php
+++ b/mod/gc_mobile_api/models/event.php
@@ -313,6 +313,9 @@ function get_events_by_owner($user, $target, $from, $to, $limit, $offset, $lang)
 	if ($target != ''){
 		$target_entity = get_entity($target);
 	}
+	if ((!$target_entity instanceof ElggUser) && (!$target_entity instanceof ElggGroup)) {
+		return "Invalid target. Please try a different GUID.";
+	}
 
 	$params = array(
 		'type' => 'object',

--- a/mod/gc_mobile_api/models/event.php
+++ b/mod/gc_mobile_api/models/event.php
@@ -107,17 +107,17 @@ elgg_ws_expose_function(
 		"enddate" => array('type' =>'string', 'required' => true),
 		"endtime" => array('type' =>'string', 'required' => false,'default' => ''),
 		"venue" => array('type' =>'string', 'required' => true),
-		"room" => array('type' =>'string', 'required' => false,'default' => ''),		
+		"room" => array('type' =>'string', 'required' => false,'default' => ''),
 		"allday" => array('type' =>'string', 'required' => false,'default' => ''),
-		"web_conference" => array('type' =>'string', 'required' => false,'default' => ''),				
-		"url" => array('type' =>'string', 'required' => false,'default' => ''),				
-		"additionnal" => array('type' =>'string', 'required' => false,'default' => ''),						
-		"fees" => array('type' =>'string', 'required' => false,'default' => ''),								
-		"contact_checkbox" => array('type' =>'string', 'required' => false,'default' => ''),								
-		"contact_text" => array('type' =>'string', 'required' => false,'default' => ''),								
-		"contact_email_text" => array('type' =>'string', 'required' => false,'default' => ''),								
+		"web_conference" => array('type' =>'string', 'required' => false,'default' => ''),
+		"url" => array('type' =>'string', 'required' => false,'default' => ''),
+		"additionnal" => array('type' =>'string', 'required' => false,'default' => ''),
+		"fees" => array('type' =>'string', 'required' => false,'default' => ''),
+		"contact_checkbox" => array('type' =>'string', 'required' => false,'default' => ''),
+		"contact_text" => array('type' =>'string', 'required' => false,'default' => ''),
+		"contact_email_text" => array('type' =>'string', 'required' => false,'default' => ''),
 		"contact_phone_text" => array('type' =>'string', 'required' => false,'default' => ''),
-		'picker_language'=> array('type' =>'string', 'required' => false,'default' => ''),															
+		'picker_language'=> array('type' =>'string', 'required' => false,'default' => ''),
 		"container_guid" => array('type' =>'string', 'required' => false, 'default' => ''),
 		"event_guid" => array('type' =>'string', 'required' => false, 'default' => ''),
 		"comments" => array('type' =>'int', 'required' => false, 'default' => 1),
@@ -241,7 +241,7 @@ function get_events($user, $from, $to, $limit, $offset, $lang)
 
 		$eventObj = get_entity($event->guid);
 		if (($eventObj->start_date > $now-$one_day) || ($eventObj->end_date && ($eventObj->end_date > $now-$one_day))) {
-			
+
 			$options = array(
 				'type' => 'user',
 				'relationship' => 'personal_event',
@@ -276,7 +276,7 @@ function get_events($user, $from, $to, $limit, $offset, $lang)
 			$event->userDetails = get_user_block($event->owner_guid, $lang);
 			$event->startDate = date("Y-m-d H:i:s", $eventObj->start_date);
 			$event->endDate = date("Y-m-d H:i:s", $eventObj->end_date);
-	
+
 			$event->location = $eventObj->venue;
 
 			if ($eventObj->group_guid){
@@ -338,7 +338,7 @@ function get_events_by_owner($user, $from, $to, $limit, $lang)
 
 		$eventObj = get_entity($event->guid);
 		if (($eventObj->start_date > $now-$one_day) || ($eventObj->end_date && ($eventObj->end_date > $now-$one_day))) {
-		
+
 			$likes = elgg_get_annotations(array(
 				'guid' => $event->guid,
 				'annotation_name' => 'likes'
@@ -366,7 +366,7 @@ function get_events_by_owner($user, $from, $to, $limit, $lang)
 				$group = get_entity($eventObj->group_guid);
 				$event->group = gc_explode_translation($group->name, $lang);
 				$event->groupGUID = $eventObj->group_guid;
-			}		
+			}
 		}
 	}
 	return $events;
@@ -386,7 +386,7 @@ function get_events_by_colleagues($user, $from, $to, $limit, $lang)
 		login($user_entity);
 	}
 	$friends = $user_entity->getFriends(array('limit' => false));
-	
+
 	if ($friends) {
 		$friend_guids = array();
 
@@ -430,7 +430,7 @@ function get_events_by_colleagues($user, $from, $to, $limit, $lang)
 
 			$eventObj = get_entity($event->guid);
 			if (($eventObj->start_date > $now-$one_day) || ($eventObj->end_date && ($eventObj->end_date > $now-$one_day))) {
-			
+
 				$likes = elgg_get_annotations(array(
 					'guid' => $event->guid,
 					'annotation_name' => 'likes'
@@ -544,7 +544,7 @@ function save_event($user, $title, $body, $startdate, $starttime, $enddate, $end
 	 }
 
 	$startdate = new DateTime($startdate);
-	$enddate = new DateTime($enddate);	
+	$enddate = new DateTime($enddate);
 
 	 $event_calendar_repeating_events = elgg_get_plugin_setting('repeating_events', 'event_calendar');
 	 // temporary place to store values
@@ -558,8 +558,8 @@ function save_event($user, $title, $body, $startdate, $starttime, $enddate, $end
 		 $event->subtype = 'event_calendar';
 		 $event->owner_guid = $user_guid;
 		 $event->container_guid = $event->owner_guid;
-	 
- 
+
+
 	 if ($e->schedule_type != 'poll') {
 		 if ($e->schedule_type == 'all_day') {
 			 $start_date_text = $startdate;
@@ -574,15 +574,15 @@ function save_event($user, $title, $body, $startdate, $starttime, $enddate, $end
 		 } else {
 			 $e->end_date = '';
 		 }
- 
+
 		 if ($e->schedule_type != 'all_day') {
 			$start_time_exp = explode(':',$starttime);
 			$start_time =60*$start_time_exp[0]+$start_time_exp[1];
-			$e->start_time = $start_time; 
-			
+			$e->start_time = $start_time;
+
 			$end_time_exp = explode(':',$endtime);
 	 		$end_time =60*$end_time_exp[0]+$end_time_exp[1];
- 			$e->end_time = $end_time;  
+ 			$e->end_time = $end_time;
 			if (is_numeric($e->start_date) && is_numeric($e->start_time)) {
 				// Set start date to the Unix start time, if set.
 				// This allows sorting by date *and* time.
@@ -612,36 +612,36 @@ function save_event($user, $title, $body, $startdate, $starttime, $enddate, $end
 		$e->contact_email = $user_entity->email;
 		$e->contact = $user_entity->name;
 	 }
-	 
+
 	 $e->organiser = $user_entity->name;
 	 //$e->tags = string_to_tag_array(get_input('tags'));
 	 $e->description = JSON_encode($bodies);
 	 //$e->group_guid = get_input('group_guid');
 	 $e->room = $room;
-	 
+
 	 // sanity check
 	 if ($e->schedule_type == 'fixed' && $e->real_end_time <= $e->start_date) {
 		 register_error(elgg_echo('event_calander:end_before_start:error'));
 		 return "error 1";
 	 }
- 
+
 	 if ($e->teleconference_radio == 'no'){
 		 $e->teleconference = '';
 		 $e->calendar_additional = '';
- 
+
 	 }
- 
+
  if((!$e->title)||(!$e->start_date) || (!$e->end_date)){
 	 return 'Missing title, start date or end date';
  }
- 
+
  //Validation if recurrence box is check
  if ($event_calendar_repeating_events != 'no') {
 	 $validation ='';
 	 $repeats = get_input('repeats');
 	 $e->repeats = $repeats;
 	 if ($repeats == 'yes') {
- 
+
 		 $dow = array('monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday');
 		 foreach ($dow as $w) {
 			 $v = 'event-calendar-repeating-'.$w.'-value';
@@ -717,9 +717,9 @@ function save_event($user, $title, $body, $startdate, $starttime, $enddate, $end
 		'subject_guid' => $user_entity->guid,
 		'object_guid' => $event->guid,
 	));
-	
+
 	if ($event->schedule_type == 'poll')
 		forward('event_poll/add/'.$event->guid);
-	
+
 	return elgg_echo('event_calendar:add_event_response');
 }

--- a/mod/gc_mobile_api/models/event.php
+++ b/mod/gc_mobile_api/models/event.php
@@ -214,13 +214,19 @@ function get_events($user, $from, $to, $limit, $offset, $lang)
 		'type' => 'object',
 		'subtype' => 'event_calendar',
 		'limit' => $limit,
-		'order_by_metadata' => array(array('name' => 'start_date', 'direction' => 'DESC', 'as' => 'integer'))
+		'order_by_metadata' => array(array('name' => 'start_date', 'direction' => 'ASC', 'as' => 'integer'))
 	);
-
-	if ($from) {
+	$now = time();
+	if ($from && ($now<strtotime($from))) {
 		$params['metadata_name_value_pairs'][] = array(
 			'name' => 'start_date',
 			'value' => strtotime($from),
+			'operand' => '>='
+		);
+	} else {
+		$params['metadata_name_value_pairs'][] = array(
+			'name' => 'start_date',
+			'value' => $now,
 			'operand' => '>='
 		);
 	}
@@ -234,7 +240,6 @@ function get_events($user, $from, $to, $limit, $offset, $lang)
 
 	$all_events = elgg_list_entities_from_metadata($params);
 	$events = json_decode($all_events);
-	$now = time();
 	$one_day = 60*60*24;
 
 	foreach ($events as $event) {


### PR DESCRIPTION
Events API, changes impact: get_events, get_events_by_owner, and get_events_by_colleagues

As part of checking the `from` variable passed in, will check it compared to `now`. If no from, or it is in the past, will default to using now as the from. Therefore it will never start from the past, only future events.
Direction changed to ASCending rather than descending, to progress to future events, not past events.

Offsets added as variables to be passed in, and to be used in params.

events_by_owner: Changed method from filter/realtionship to just using  a passed in target guid as the container guid. Allows multiple uses, allowing for group and user's as the target, instead of just the user logged in. Has a check to verify target is a user or group.