### PR TITLE
Mobile API Comment Count

### DIFF
--- a/mod/gc_mobile_api/models/blog.php
+++ b/mod/gc_mobile_api/models/blog.php
@@ -134,7 +134,11 @@ function foreach_blogs($blogs, $user_entity, $lang)
 		));
 		$blog_post->liked = count($liked) > 0;
 
-		$blog_post->comments = get_entity_comments($blog_post->guid);
+		$blog_post->comment_count = elgg_get_entities(array(
+			'container_guid' => $guid,
+			'count' => true,
+			'distinct' => false,
+		));
 
 		$blog_post->userDetails = get_user_block($blog_post->owner_guid, $lang);
 
@@ -190,7 +194,11 @@ function get_blogpost($user, $guid, $lang)
 	));
 	$blog_post->liked = count($liked) > 0;
 
-	$blog_post->comments = get_entity_comments($blog_post->guid);
+	$blog_post->comment_count = elgg_get_entities(array(
+		'container_guid' => $guid,
+		'count' => true,
+		'distinct' => false,
+	));
 
 	$blog_post->userDetails = get_user_block($blog_post->owner_guid, $lang);
 

--- a/mod/gc_mobile_api/models/bookmark.php
+++ b/mod/gc_mobile_api/models/bookmark.php
@@ -110,9 +110,13 @@ function get_bookmark($user, $guid, $lang)
     $bookmarkObject = get_entity($bookmark->guid);
     $bookmark->description = gc_explode_translation($bookmarkObject->description, $lang);
     $bookmark->address = $bookmarkObject->address;
-
     $bookmark->userDetails = get_user_block($bookmark->owner_guid, $lang); //Should go through and only pass revelant infromation
     $bookmark->group_guid = "";
+		$bookmark->comment_count = elgg_get_entities(array(
+			'container_guid' => $guid,
+			'count' => true,
+			'distinct' => false,
+		));
     if ($bookmark->container_guid != $bookmark->owner_guid){
       $bookmark->group_guid = $bookmark->container_guid;
       $bookmarkGroup = get_entity($bookmark->group_guid);

--- a/mod/gc_mobile_api/models/discussion.php
+++ b/mod/gc_mobile_api/models/discussion.php
@@ -116,24 +116,15 @@ function get_discussion($user, $guid, $thread, $lang)
 	$discussion->userDetails = get_user_block($discussion->owner_guid, $lang);
 	$discussion->description = gc_explode_translation($discussion->description, $lang);
 
-	$discussionsArray = array();
-	$discussionsArray[] = $discussion;
-
 	if ($thread) {
-		$all_replies = elgg_list_entities_from_metadata(array(
-			'type' => 'object',
-			'subtype' => 'discussion_reply',
-			'container_guid' => $guid
+		$discussion->comment_count = elgg_get_entities(array(
+			'container_guid' => $guid,
+			'count' => true,
+			'distinct' => false,
 		));
-		$replies = json_decode($all_replies);
-		$replies = array_reverse($replies);
-
-		foreach ($replies as $reply) {
-			$discussionsArray[] = $reply;
-		}
 	}
 
-	return $discussionsArray;
+	return $discussion;
 }
 
 function get_discussions($user, $limit, $offset, $filters, $lang)

--- a/mod/gc_mobile_api/models/event.php
+++ b/mod/gc_mobile_api/models/event.php
@@ -193,7 +193,11 @@ function get_event($user, $guid, $lang)
 		$event->group = gc_explode_translation($group->name, $lang);
 		$event->groupGUID = $eventObj->group_guid;
 	}
-
+	$event->comment_count = elgg_get_entities(array(
+		'container_guid' => $guid,
+		'count' => true,
+		'distinct' => false,
+	));
 
 	return $event;
 }


### PR DESCRIPTION
Added comment counts for Bookmark, Event, Blog(s), and Discussion.

Removed grabbing full replies in blog(s) and discussion. Already handled with a separate API when specifically requested.

https://github.com/gctools-outilsgc/gccollab-mobile/issues/145