### PR TITLE
Group profile sidebar fix

### DIFF
--- a/mod/gc_group_layout/lib/groups.php
+++ b/mod/gc_group_layout/lib/groups.php
@@ -356,10 +356,10 @@ function groups_handle_profile_page($guid) {
 	$content = elgg_view('groups/profile/layout', array('entity' => $group));
 	$sidebar_value = $group->getPrivateSetting('group_tools:cleanup:menu');
 
-	if($sidebar_value == 'no'){
+	if(!$sidebar_value || $sidebar_value == 'no'){
 		$sidebar = elgg_view('groups/sidebar/sidebar', array('entity' => $group));
 	}
-	
+
 	$params = array(
 		'content' => $content,
 		'sidebar' => $sidebar,
@@ -559,7 +559,7 @@ function groups_register_profile_buttons($group) {
 			$url = elgg_add_action_tokens_to_url($url);
 			$actions[$url] = 'groups:leave';
 		}
-		
+
 		if( strpos(elgg_get_site_entity()->name, 'collab') !== false ){
 			$url = elgg_get_site_url() . "groups/stats/{$group->getGUID()}";
 			$actions[$url] = 'groups:stats';
@@ -768,8 +768,8 @@ function groups_handle_stats_page($guid) {
     <style>
     .chart {
         width: 100%;
-        min-width: 100%; 
-        max-width: 100%; 
+        min-width: 100%;
+        max-width: 100%;
         margin: 0 auto;
     }
     .chart .loading {
@@ -778,7 +778,7 @@ function groups_handle_stats_page($guid) {
         font-size: 2em;
         text-align: center;
     }
-    @media (max-width: 480px) { 
+    @media (max-width: 480px) {
         .nav-tabs > li {
             float:none;
         }


### PR DESCRIPTION
By default when a group is created the group profile sidebar would be hidden. The only way to make it appear was to go into in the admin settings section of the group settings and save the form in it's default state.

Added check to see if the value the if statement used wasn't set yet.