### PR TITLE
load chat scripts from another subdomain

### DIFF
--- a/mod/wet4_collab/views/default/page/elements/html.php
+++ b/mod/wet4_collab/views/default/page/elements/html.php
@@ -34,9 +34,13 @@ if (isset($vars['body_attrs'])) {
 <html class="no-js" lang="<?php echo $lang; ?>" dir="ltr">
 <meta http-equiv="X-UA-Compatible" content="IE=edge" />
 <!--<![endif]-->
+<script>
+var userid = ''<?php echo elgg_get_logged_in_user_guid() ?>;
+document.cookie = "cc_data="+userid;
+</script>
 <head>
-    <link type="text/css" href="/cometchat/cometchatcss.php" rel="stylesheet" charset="utf-8">
-    <script type="text/javascript" src="/cometchat/cometchatjs.php" charset="utf-8"></script>
+    <link type="text/css" href="https://comet-dev.gccollab.ca/cometchat/cometchatcss.php" rel="stylesheet" charset="utf-8">
+    <script type="text/javascript" src="https://comet-dev.gccollab.ca/cometchat/cometchatjs.php" charset="utf-8"></script>
     <?php
         echo str_replace("_graphics/favicon", "_graphics/favicon-collab", $vars["head"]);
     ?>

--- a/mod/wet4_collab/views/default/page/elements/html.php
+++ b/mod/wet4_collab/views/default/page/elements/html.php
@@ -39,8 +39,8 @@ var userid = ''<?php echo elgg_get_logged_in_user_guid() ?>;
 document.cookie = "cc_data="+userid;
 </script>
 <head>
-    <link type="text/css" href="https://comet-dev.gccollab.ca/cometchat/cometchatcss.php" rel="stylesheet" charset="utf-8">
-    <script type="text/javascript" src="https://comet-dev.gccollab.ca/cometchat/cometchatjs.php" charset="utf-8"></script>
+    <link type="text/css" href="https://comet.gccollab.ca/cometchatcss.php" rel="stylesheet" charset="utf-8">
+    <script type="text/javascript" src="https://comet.gccollab.ca/cometchatjs.php" charset="utf-8"></script>
     <?php
         echo str_replace("_graphics/favicon", "_graphics/favicon-collab", $vars["head"]);
     ?>


### PR DESCRIPTION
Or maybe it should just be removed in favour of message.gccollab.ca considering how much better that works.