### PR TITLE
Toggle language creating ajax error

### DIFF
--- a/mod/toggle_language/views/default/toggle_language/toggle_lang.php
+++ b/mod/toggle_language/views/default/toggle_language/toggle_lang.php
@@ -14,6 +14,11 @@
 		}
 
 		$cookie_name = "lang";
+
+		if (isset($SESSION['language']) ){
+			$SESSION['language'] = 'en';
+		}
+
 	?>
 
 	<script type="text/javascript">


### PR DESCRIPTION
I was not able to replicate but I test, at different place, changing, removing and deleting the value. I never get an ajax error, so I create a default value when the var does not exist. The code already have a default value if it not equal to 'en'.

Potential fix for https://github.com/gctools-outilsgc/gccollab/issues/364