### PR TITLE
Allow solr crawler to crawl without logging in the usual way

### DIFF
--- a/mod/loginrequired/start.php
+++ b/mod/loginrequired/start.php
@@ -74,6 +74,9 @@ function loginrequired_init() {
 	$allow[] = 'mod/contactform/';
 	$allow[] = 'thewire_image/download/.*';
 
+	if (getenv('SOLR_CRAWLER') != '' && $_SERVER['HTTP_USER_AGENT'] === getenv('SOLR_CRAWLER'))
+		$allow[] = '.*';
+
 
 	// Allow other plugin developers to edit the array values
 	$add_allow = elgg_trigger_plugin_hook('login_required','login_required');


### PR DESCRIPTION
The sitemap will take if from here, should work the same a crawling GCconnex with this.
I'll set up https://dev.gccollab.ca to test this.

fixes gctools-outilsgc/gccollab#360
