### PR TITLE
collab stats page rolled back to highcharts 6.1.0 (charts now load correctly)

### DIFF
--- a/mod/gccollab_stats/pages/gccollab_stats/gccollab.php
+++ b/mod/gccollab_stats/pages/gccollab_stats/gccollab.php
@@ -13,7 +13,7 @@
 
         ob_start(); ?>
 
-        <script src="//code.highcharts.com/highcharts.js"></script>
+        <script src="//code.highcharts.com/6.1.0/highcharts.js"></script>
         <script src="//code.highcharts.com/modules/exporting.js"></script>
         <script src="//code.highcharts.com/modules/data.js"></script>
         <script src="//code.highcharts.com/modules/drilldown.js"></script>

--- a/mod/gccollab_stats/pages/gccollab_stats/gcconnex.php
+++ b/mod/gccollab_stats/pages/gccollab_stats/gcconnex.php
@@ -13,7 +13,7 @@
 
         ob_start(); ?>
 
-        <script src="//code.highcharts.com/highcharts.js"></script>
+        <script src="//code.highcharts.com/6.1.0/highcharts.js"></script>
         <script src="//code.highcharts.com/modules/exporting.js"></script>
         <script src="//code.highcharts.com/modules/data.js"></script>
         <script src="//code.highcharts.com/modules/drilldown.js"></script>


### PR DESCRIPTION
New changes to Highcharts prevented the collab stats page from loading. Reverting to previous version seems to fix the issue.