### PR TITLE
Freshdesk feedback error

### DIFF
--- a/mod/freshdesk_help/start.php
+++ b/mod/freshdesk_help/start.php
@@ -11,7 +11,7 @@ function freshdesk_help_init() {
     elgg_register_action('save-articles', elgg_get_plugins_path() . "/freshdesk_help/actions/articles/save.php");
     elgg_register_action('save-articles-pedia', elgg_get_plugins_path() . "/freshdesk_help/actions/articles/pedia-save.php");
 
-    elgg_register_action('ticket/feedback', elgg_get_plugins_path() . "/freshdesk_help/actions/ticket/feedback.php");
+    elgg_register_action('ticket/feedback', elgg_get_plugins_path() . "/freshdesk_help/actions/ticket/feedback.php", "public");
 
     elgg_extend_view("js/elgg", "js/freshdesk_help/functions");
     elgg_extend_view('css/elgg', 'freshdesk/css');


### PR DESCRIPTION
Made feedback action public so it won't appear to give an error when submitting a ticket. When submitting a ticket, the proper feedback will now appear.

Was not able to recreate the 401 authorization error pictured in original issue. Judging by the improper language variable, i would say it was something wrong with the site when user was submitting ticket.

Closes #1923 