### PR TITLE
Performance enhancements to recommendation provider API

### DIFF
--- a/mod/missions/api/v0/api.php
+++ b/mod/missions/api/v0/api.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
 * NRC Recommendation Platform API Library
 * Copyright (c) 2017 National Research Council Canada
@@ -8,6 +7,46 @@
 *
 */
 header('Content-Type: application/json');
+
+global $subtypes;
+
+class FakeGUIDEntity {
+  public $guid;
+  public function __construct($guid) {
+    $this->guid = $guid;
+  }
+}
+
+class FakeEntity extends \ElggEntity {
+  private $entity;
+  public function __construct($entity) {
+    $this->entity = $entity;
+  }
+  public function __get($name) {
+    return $this->entity->$name;
+  }
+  public function getType() {
+    return $this->entity->type;
+  }
+  public function getSubtype() {
+    global $subtypes;
+    return $subtypes["i_{$this->entity->subtype}"];
+  }
+  public function getOwnerEntity() {
+    if ($this->entity->owner_guid > 0) {
+      return new FakeGUIDEntity($this->entity->owner_guid);
+    } else return false;
+  }
+  public function getDisplayName() {
+    return $this->entity->name;
+  }
+  public function getContainerEntity() {
+    if ($this->entity->container_guid > 0) {
+      return new FakeGUIDEntity($this->entity->container_guid);
+    } else return false;
+  }
+  public function setDisplayName($displayName) {}
+}
 
 /**
 * Verify that the API request has the appropriate X-Custom-Authorization
@@ -34,10 +73,45 @@ function mm_api_secure() {
   # Increase the script timeout value
   set_time_limit(14400);
 }
+global $CONFIG;
+function getURL($entity) {
+  global $CONFIG;
+  global $subtypes;
+  $type = $entity->type;
+  $subtype = $subtypes["i_{$entity->subtype}"];
+
+  $url = '';
+
+  if (isset($CONFIG->entity_url_handler[$type][$subtype])) {
+    $function = $CONFIG->entity_url_handler[$type][$subtype];
+    if (is_callable($function)) {
+      $url = call_user_func($function, $entity);
+    }
+  } elseif (isset($CONFIG->entity_url_handler[$type]['all'])) {
+    $function = $CONFIG->entity_url_handler[$type]['all'];
+    if (is_callable($function)) {
+      $url = call_user_func($function, $entity);
+    }
+  } elseif (isset($CONFIG->entity_url_handler['all']['all'])) {
+    $function = $CONFIG->entity_url_handler['all']['all'];
+    if (is_callable($function)) {
+      $url = call_user_func($function, $entity);
+    }
+  }
+
+  if ($url) {
+    $url = elgg_normalize_url($url);
+  }
+
+  $params = array('entity' => new FakeEntity($entity));
+  $url = _elgg_services()->hooks->trigger('entity:url', $type, $params, $url);
+
+  return elgg_normalize_url($url);
+}
+
 
 /**
-* Generator that finds the GUIDs of the entities defined by the search critera.
-* The first value yielded is the total number of guids found.
+* Stream the requested entities as efficently as possible using JSON.
 *
 * @param str $type Desired entity type.  (object, user, export)
 * @param str $subtype Desired subtype.  (mission)
@@ -49,19 +123,116 @@ function mm_api_secure() {
 * @param bool $sort: If true sorts entities based on time created.
 * @param str $omit: Comma separated list of GUIDs to omit.
 *
-* @return Generator[] Guid iterable
+* @return Generator[] JSON formatted text stream
 */
-function mm_api_get_entity_guids($type, $subtype = false, $guid = null,
+function mm_api_export_entities($type, $subtype = false, $guid = null,
 $since = null, $before = null, $limit = null, $resume = null, $sort = false,
-$omit = null) {
+$omit = null, $countRows = false) {
+  _elgg_services()->db->establishLink('api_exporter');
+  $dbprefix = elgg_get_config('dbprefix');
+  $dblink = _elgg_services()->db->getLink('read');
+  function dismount($object) {
+    $reflectionClass = new ReflectionClass(get_class($object));
+    $array = array();
+    foreach ($reflectionClass->getProperties() as $property) {
+        $property->setAccessible(true);
+        $array[$property->getName()] = $property->getValue($object);
+        $property->setAccessible(false);
+    }
+    return $array;
+  }
+  global $in_array;
+  $in_array = false;
+  function outVal($val, $start_with_comma=true) {
+    global $in_array;
+    $value = ($val->meta_type === 'integer') ?
+      json_encode(intval($val->meta_value)) : json_encode($val->meta_value);
+    if (($in_array !== false) && ($in_array == $val->meta_name)) {
+      return (($start_with_comma) ? ',' : '').$value;
+    }
+    $ret = '';
+    if (($in_array !== false) && (($in_array != $val->meta_name) || ($val->arr == 0))) {
+      $ret .= ']';
+      $in_array = false;
+    }
+    if ($start_with_comma) $ret .= ',';
+    $ret .= '"' . $val->meta_name . '":';
+    if ($val->arr != 0) {
+      $ret .= '[';
+      $in_array = $val->meta_name;
+    }
+    $ret .= $value;
+    return $ret;
+  }
+  function finalizeEntity($uguid) {
+    global $in_array;
+    $dbprefix = elgg_get_config('dbprefix');
+    $dblink = _elgg_services()->db->getLink('read');
+
+    if ($uguid > 0) {
+      if ($in_array) {
+        yield ']';
+        $in_array = false;
+      }
+
+      $options = array('guid' => $uguid, 'limit' => 0);
+      $annotations = elgg_get_annotations($options);
+
+      if ($annotations) {
+        $data = [ 'annotations' => []];
+        foreach ($annotations as $v) {
+          if (!isset($data['annotations'][$v->name])) {
+            $data['annotations'][$v->name] = [];
+          };
+          $data['annotations'][$v->name][] = dismount($v);
+        }
+        yield ','.substr(json_encode($data), 1, -1);
+      }
+      yield ',"relationships":[';
+
+      $relstart = false;
+      $reltable = "{$dbprefix}entity_relationships";
+      $relationships = mysql_unbuffered_query(
+        "SELECT * from $reltable where guid_one = " .
+        mysql_escape_string($uguid) .
+        ' OR guid_two = ' . mysql_escape_string($uguid),
+        $dblink
+      );
+      while ($v = mysql_fetch_object($relationships)) {
+        yield (($relstart) ? ',' : '') . json_encode(array(
+          'direction' => ($v->guid_one == $uguid) ? 'OUT' : 'IN',
+          'time_created' => $v->time_created,
+          'id' => $v->id,
+          'relationship' => $v->relationship,
+          'entity' => ($v->guid_one == $uguid) ? $v->guid_two : $v->guid_one,
+        ));
+        $relstart = true;
+      }
+      mysql_free_result($relationships);
+      yield ']}';
+    }
+  }
+
+  // Get all subtypes
+  global $subtypes;
+  $subtypes = [];
+  $subtype_results = mysql_unbuffered_query(
+    "select id, subtype from {$dbprefix}entity_subtypes",
+    $dblink
+  );
+  while ($row = mysql_fetch_object($subtype_results)) {
+    $subtypes["i_{$row->id}"] = $row->subtype;
+    $subtypes["s_{$row->subtype}"] = $row->id;
+  }
+  mysql_free_result($subtype_results);
+
   $where = ['a.enabled = "yes"'];
   if ($type !== 'export') {
     $where[] = 'a.type = "' . mysql_escape_string($type) . '"';
   }
   if ($subtype !== false) {
-    $subtype_id = get_data("select id from ".elgg_get_config('dbprefix')."entity_subtypes where subtype = '$subtype'")[0]->id;
-    $where[] = 'a.subtype = ' . $subtype_id;
-  } else $subtype_id = 0;
+    $where[] = 'a.subtype = ' . (($subtypes["s_$subtype"]) ? $subtypes["s_$subtype"] : -1);
+  }
 
   if (!is_null($guid) && is_numeric($guid)) {
     $where[] = 'a.guid = ' . mysql_escape_string(intval($guid));
@@ -91,23 +262,120 @@ $omit = null) {
     $sort_sql = 'ORDER BY a.time_updated ASC';
   }
   try {
-    $sql = '
+    $sql = "
     SELECT
-      a.guid
+      a.guid,
+      a.type,
+      a.subtype,
+      a.owner_guid,
+      a.site_guid,
+      a.container_guid,
+      a.time_created,
+      a.time_updated,
+      a.access_id,
+      a.enabled,
+      a.last_action,
+      o.title,
+      o.description,
+      u.name,
+      u.username,
+      u.admin,
+      u.banned,
+      u.language,
+      u.last_action AS user_last_action,
+      u.prev_last_action,
+      u.last_login,
+      u.prev_last_login,
+      g.name as group_name,
+      g.description as group_description,
+      (
+        SELECT
+          COUNT(name_id)
+        FROM
+          elggmetadata
+        WHERE
+          entity_guid = a.guid
+          AND name_id = b.name_id
+      ) > 1 as arr,
+      b.value_type as meta_type,
+      c.string as meta_name,
+      d.string as meta_value
     FROM
-      '.elgg_get_config('dbprefix').'entities a
-    ' . $where_sql . '
-    ' . $sort_sql;
-    $result = mysql_query($sql, _elgg_services()->db->getLink('read'));
-    yield mysql_num_rows($result);
+      {$dbprefix}entities a
+      LEFT JOIN {$dbprefix}objects_entity o on o.guid = a.guid
+      LEFT JOIN {$dbprefix}users_entity u ON u.guid = a.guid
+      LEFT JOIN {$dbprefix}groups_entity g ON g.guid = a.guid
+      LEFT JOIN {$dbprefix}metadata b ON b.entity_guid = a.guid
+      LEFT JOIN {$dbprefix}metastrings c ON c.id = b.name_id
+      LEFT JOIN {$dbprefix}metastrings d ON d.id = b.value_id
+    $where_sql
+    $sort_sql";
+
+    if ($countRows) {
+      yield get_data(
+        "select count(guid) c from {$dbprefix}entities a $where_sql"
+      )[0]->c;
+    } else yield 0;
+
+    $entity_data = mysql_unbuffered_query(
+      $sql,
+      _elgg_services()->db->getLink('api_exporter')
+    );
     $emit = !is_numeric($resume);
     $max = (is_numeric($limit) && ($limit > 0)) ? $limit : false;
     $count = 0;
-    while ($row = mysql_fetch_object($result)) {
+    $currentGuid = -1;
+    $uguid = -1;
+    $euguid = -1;
+    while ($row = mysql_fetch_object($entity_data)) {
       if ($emit) {
-        $count += 1;
-        yield $row->guid;
-        if (($max !== false) && ($count >= $max)) break;
+        if ($currentGuid != $row->guid) {
+          $fin = finalizeEntity($currentGuid);
+          foreach ($fin as $fs) yield $fs;
+          $currentGuid = -1;
+          $count += 1;
+          if (($max !== false) && ($count > $max)) break;
+          yield ',';
+          yield '{';
+          $currentGuid = $row->guid;
+          $euguid = mysql_escape_string(intval($row->guid));
+          $uguid = $row->guid;
+
+          yield '"guid":' . $row->guid . ',' .
+            '"type":"' . $row->type . '",' .
+            '"subtype":' . $row->subtype . ',' .
+            '"subtype_name":' . json_encode($subtypes["i_{$row->subtype}"]) . ',' .
+            '"time_created":' . $row->time_created . ',' .
+            '"url":' . json_encode(getURL($row)) . ',' .
+            '"access_id":' . $row->access_id . ',' .
+            '"time_updated":' . $row->time_updated . ',' .
+            '"owner_guid":' . $row->owner_guid . ',' .
+            '"container_guid":' . $row->container_guid . ',' .
+            '"enabled":"' . $row->enabled . '",' .
+            '"site_guid":' . $row->site_guid;
+          if (!is_null($row->title)) {
+            yield ',"title":' . json_encode($row->title) . ',' .
+              '"description":' . json_encode($row->description);
+          }
+          if (!is_null($row->group_name)) {
+            yield ',"name":' . json_encode($row->group_name) . ',' .
+              '"description":' . json_encode($row->group_description);
+          }
+          if (!is_null($row->name)) {
+            yield ',"name":' . json_encode($row->name) . ',' .
+              '"username":' . json_encode($row->username) . ',' .
+              '"language":"' . $row->language . '",' .
+              '"admin":"' . $row->admin . '",' .
+              '"banned":"' . $row->banned . '",' .
+              '"last_action":' . $row->user_last_action . ',' .
+              '"prev_last_action":' . $row->prev_last_action . ',' .
+              '"last_login":' . $row->last_login . ',' .
+              '"prev_last_login":' . $row->prev_last_login;
+          } else {
+            yield ',"last_action":' . $row->last_action;
+          }
+        }
+        if (!is_null($row->meta_name)) yield outVal($row);
       }
       if (!$emit) {
         if ($row->guid == $resume) {
@@ -115,127 +383,12 @@ $omit = null) {
         }
       }
     }
-  } catch (Exception $e) {
-    //
-  }
-}
-
-/**
-* Iterate over list of GUIDs and yields the complete object as a row.
-*
-* @param mixed $entity_guids Array of entity GUIDs
-*/
-function mm_api_entity_export($entity_guids) {
-  function createInvalidEntityObject($guid) {
-    $ret = new \stdClass;
-    $ret->guid = $guid;
-    $ret->__error__ = 'Incomplete Entity Error';
-    return $ret;
-  }
-  function exportEntity($entity_or_guid) {
-    // List of fields not to include in any export
-    $omit = array('password', 'password_hash', 'salt');
-    if (is_object($entity_or_guid)) {
-      $entity = $entity_or_guid;
-    } else {
-      $entity = get_entity($entity_or_guid);
-      if (!is_object($entity)) {
-        $invalidObj = createInvalidEntityObject($entity_or_guid);
-        return [$invalidObj, $invalidObj];
-      }
+    if ($currentGuid > 0) {
+      $fin = finalizeEntity($currentGuid);
+      foreach ($fin as $fs) yield $fs;
     }
-    $ret = new \stdClass;
-    $exportable_values = $entity->getExportableValues();
-    foreach ($exportable_values as $v) {
-      $ret->$v = $entity->$v;
-    }
-    foreach ($entity as $field=>$value) {
-      if (!in_array($field, $exportable_values) && !in_array($field, $omit)) {
-        $ret->$field = $value;
-      }
-    }
-    $ret->url = $entity->getURL();
-    $ret->subtype_name = $entity->getSubtype();
-    return [$entity, $ret];
-  }
-  function dismount($object) {
-    $reflectionClass = new ReflectionClass(get_class($object));
-    $array = array();
-    foreach ($reflectionClass->getProperties() as $property) {
-        $property->setAccessible(true);
-        $array[$property->getName()] = $property->getValue($object);
-        $property->setAccessible(false);
-    }
-    return $array;
-  }
-
-  while ($entity_guids->valid()) {
-    yield ',';
-
-    $uguid = $entity_guids->current();
-    $objectData = exportEntity($uguid);
-    $object = $objectData[0];
-    $data = $objectData[1];
-
-    $options = array(
-      'guid' => $object->guid,
-      'limit' => 0
-    );
-
-    $metadata = elgg_get_metadata($options);
-    $annotations = elgg_get_annotations($options);
-
-    if ($metadata) {
-      foreach ($metadata as $v) {
-        $prop = $v->name;
-        if (!isset($data->$prop)) $data->$prop = $object->$prop;
-      }
-    }
-    if ($annotations) {
-      foreach ($annotations as $v) {
-        if (!isset($data->annotations[$v->name])) {
-          $data->annotations[$v->name] = [];
-        };
-        $data->annotations[$v->name][] = dismount($v);
-      }
-    }
-    yield '{'.substr(json_encode($data), 1, -1) . ',"relationships":[';
-
-    $relstart = false;
-    $reltable = elgg_get_config('dbprefix') . 'entity_relationships';
-    $relationships = mysql_unbuffered_query(
-      "SELECT * from $reltable where guid_one = {$object->guid}",
-      _elgg_services()->db->getLink('read')
-    );
-    while ($v = mysql_fetch_object($relationships)) {
-      yield (($relstart) ? ',' : '') . json_encode(array(
-        'direction' => 'OUT',
-        'time_created' => $v->time_created,
-        'id' => $v->id,
-        'relationship' => $v->relationship,
-        'entity' => $v->guid_two,
-      ));
-      $relstart = true;
-    }
-    mysql_free_result($relationships);
-
-    $relationships2 = mysql_unbuffered_query(
-      "SELECT * from $reltable where guid_two = {$object->guid}",
-      _elgg_services()->db->getLink('read')
-    );
-    while ($v = mysql_fetch_object($relationships2)) {
-      yield (($relstart) ? ',' : '') . json_encode(array(
-        'direction' => 'IN',
-        'time_created' => $v->time_created,
-        'id' => $v->id,
-        'relationship' => $v->relationship,
-        'entity' => $v->guid_one,
-      ));
-      $relstart = true;
-    }
-    mysql_free_result($relationships2);
-    yield ']}';
-    $entity_guids->next();
+} catch (Exception $e) {
+    yield ',"error": ' . json_encode($e);
   }
 }
 

--- a/mod/missions/api/v0/export.php
+++ b/mod/missions/api/v0/export.php
@@ -2,9 +2,160 @@
   namespace NRC;
 
   require_once(elgg_get_plugins_path() . 'missions/api/v0/api.php');
-  mm_api_secure();
 
   class export {
+
+    public static $version = 'v0.0.3';
+    public static $help = <<<EOD
+<!DOCTYPE html>
+<html>
+  <body>
+    <H1>
+      NRC Recommendation Provider API
+      <sub style="font-size: 0.5em">::version::</sub>
+    </H1>
+    <p>
+      This API provides the means by which recommendation services can collect
+      GCConnex data.  A private key is required to access this service.
+    </p>
+    <H3>Endpoints</H3>
+    <ul>
+      <li>
+        <h4>/missions/api/v0/export[/guid]</h4>
+        <p>
+          Used to export any entity.  If a guid is provided, only that entity
+          is returned.
+        </p>
+        Examples:
+        <ul>
+          <li>/missions/api/v0/export</li>
+          <li>/missions/api/v0/export/205</li>
+          <li>/missions/api/v0/export/42922688</li>
+          <li>/missions/api/v0/export?since=1539475200&limit=2</li>
+        </ul>
+      </li>
+      <li>
+        <h4>/missions/api/v0/user[/guid]</h4>
+        <p>
+          Used to export users.  If a guid is provided, only that user is
+          returned.
+        </p>
+        Examples:
+        <ul>
+          <li>/missions/api/v0/user</li>
+          <li>/missions/api/v0/user/205</li>
+          <li>/missions/api/v0/user?since=1539475200</li>
+        </ul>
+      </li>
+      <li>
+        <h4>
+          /missions/api/v0/object[/guid]<br>
+          /missions/api/v0/object/subtype[/guid]
+        </h4>
+        <p>
+          Used to export objects.  If a guid is provided, only that object is
+          returned.  A subtype can also be specified.
+        </p>
+        Examples:
+        <ul>
+          <li>/missions/api/v0/object</li>
+          <li>/missions/api/v0/object/42922688</li>
+          <li>/missions/api/v0/object?since=1539475200&limit=1</li>
+          <li>/missions/api/v0/object/widget?since=1539475200</li>
+        </ul>
+      </li>
+    </ul>
+    <H3>Query parameters</H3>
+    <p>Parameters can be used to perform more complex queries.</p>
+    <table>
+      <thead>
+        <tr>
+          <th>Parameter</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>before</td>
+          <td>
+            Fetch entities that have been modified before the specified time.
+            Expects a unix timetamp.
+          </td>
+        </tr>
+        <tr>
+          <td>since</td>
+          <td>
+            Fetch entities that have been modified after the specified time.
+            Expects a unix timetamp.
+          </td>
+        </tr>
+        <tr>
+          <td>limit</td>
+          <td>
+            Limits the number of returned entities.  Expects an positive
+            integer.
+          </td>
+        </tr>
+        <tr>
+          <td>resume</td>
+          <td>
+            Resume starting at the specified GUID.  Expects a valid GUID.
+          </td>
+        </tr>
+        <tr>
+          <td>sort</td>
+          <td>
+            If specified sorts returned entities by created time - By default
+            rows are returned in natural order without any sorting guarantees.
+            This parameter doesn't take any value, its presence enables
+            sorting.
+          </td>
+        </tr>
+        <tr>
+          <td>omit</td>
+          <td>
+            List of GUIDs to omit from the results.  Useful to omit large
+            objects we know we are not interested in.  For example GUID "1".
+            Takes a comma separated list of GUIDs.
+          </td>
+        </tr>
+        <tr>
+          <td>version<strong>*<strong></td>
+          <td>
+            Returns the API version as a JSON object and exits.  No query is
+            performed regardless of other parameters.
+          </td>
+        </tr>
+        <tr>
+          <td>help<strong>*<strong></td>
+          <td>
+            Returns the API help text as an HTML page and exits.  No query is
+            performed regardless of other parameters.
+          </td>
+        </tr>
+      </table>
+      <small><strong>*<strong> These parameters do not require a private key</small>
+      <H3>Returns</H3>
+      Successful queries return JSON objects like this:
+      <pre>
+      {
+        "query": {
+            "object_type": "export",     // type of export
+            "api_version": "v0.0.3",     // current API version
+            "subtype": false,            // requested subtype, if specified
+            "guid": null,                // requested GUID, if specified
+            "since": "1539475200",       // "since" parameter, if specified
+            "before": null,              // "before" parameter, if specified
+            "limit": null,               // "limit" parameter, if specified
+            "request_time": 1546958611,  // server's current unix timestamp
+            "count": 14                  // Total number of matched entities
+        },
+        "export": [ ... ]                // Array of requested entities
+      }
+      </pre>
+  </body>
+</html>
+EOD;
 
     private $object_type = false;
     private $subtype = false;
@@ -12,10 +163,18 @@
     private $since = null;
     private $before = null;
     private $limit = null;
+    private $omit = null;
+
+    static function getHelp() {
+      return str_replace('::version::', self::$version, self::$help);
+    }
 
     function __construct($object_type, $subtype = false, $guid = null,
       $since = null, $before = null, $limit = null, $resume = null,
-      $sort = false) {
+      $sort = false, $omit = null) {
+
+      mm_api_secure();
+
       $this->object_type = $object_type;
       $this->subtype = $subtype;
       $this->guid = $guid;
@@ -24,9 +183,13 @@
       $this->limit = $limit;
       $this->resume = $resume;
       $this->sort = $sort;
+      $this->omit = $omit;
     }
 
-    function getJSON() {
+    /**
+     * Stream the export results using JSON format
+     */
+    function outputJSON() {
       while (@ob_end_flush());
       $guids = mm_api_get_entity_guids(
         $this->object_type,
@@ -36,11 +199,12 @@
         $this->before,
         $this->limit,
         $this->resume,
-        $this->sort
+        $this->sort,
+        $this->omit
       );
-      echo "{\"export\": [\n";
-      $chunk_header = [ 'header' => [
+      echo '{"query":' .json_encode([
         'object_type' => $this->object_type,
+        'api_version' => self::$version,
         'subtype' => $this->subtype,
         'guid' => $this->guid,
         'since' => $this->since,
@@ -48,21 +212,22 @@
         'limit' => $this->limit,
         'request_time' => time(),
         'count' => $guids->current()
-      ]];
-      echo json_encode($chunk_header) . "\n";
+      ]). ',"export":[';
       flush();
-
+      $guids->next();
       $export = mm_api_entity_export($guids);
-      foreach ($export as $output) {
-        // $export[$object->getType()][$object->getSubtype()][] = $data;
-        echo ",\n" . json_encode($output['export']) . "\n";
-        // $row = json_encode($data[0]) . (($data[1]) ? ",\n" : "\n");
-        // echo $row;
+
+      // ignore the first comma
+      $export->next();
+
+      while ($export->valid()) {
+        $output = $export->current();
+        echo $output;
         flush();
         ob_flush();
+        $export->next();
       }
       echo "]}\r\n";
-
       exit;
     }
   }

--- a/mod/missions/start.php
+++ b/mod/missions/start.php
@@ -89,25 +89,25 @@ function missions_init()
 
     // Register an ajax view for the advanced search page.
     elgg_register_ajax_view('missions/element-select');
-    
+
     // Register an ajax view for adding a skill input field.
     elgg_register_ajax_view('missions/add-skill');
 
-    // 
+    //
     elgg_register_ajax_view('missions/analytics-inputs');
-    
+
     // Register an ajax view for generating an analytics graph.
     elgg_register_ajax_view('missions/analytics-generator');
-    
+
     // Register an ajax view for the opt in on splash
     elgg_register_ajax_view('missions/opt_in_splash');
-    
+
     //Hook which sets the url for object entities upon creation.
     elgg_register_plugin_hook_handler('entity:url', 'object', 'mission_set_url');
-    
+
     // Hook which changes how user entities are displayed.
     elgg_register_plugin_hook_handler('view', 'user/default', 'alter_mission_user_view');
-    
+
     // Changes the manager's owner block in the mission view.
     elgg_register_plugin_hook_handler('view', 'page/elements/owner_block', 'alter_mission_owner_block');
 
@@ -117,7 +117,7 @@ function missions_init()
     		'href' => elgg_get_site_url() . 'missions/main',
     		'text' => elgg_echo('missions:micromissions_menu')
     ));
-    
+
     // Adds a menu item to the admin page under the administer section in the right hand bar.
     elgg_register_menu_item('page', array(
     		'name' => 'mission_admin_tool',
@@ -172,9 +172,17 @@ function missions_main_page_handler($segments)
           if (count($segments) >= 3) {
             if ($segments[1] == 'v0') {
               include elgg_get_plugins_path() . 'missions/api/v0/export.php';
+              if (isset($_GET['version'])) {
+                die(json_encode(array("version" => NRC\export::$version)));
+              }
+              if (isset($_GET['help'])) {
+                header('Content-Type: text/html');
+                die(NRC\export::getHelp());
+              }
               $object_type = strtolower($segments[2]);
               $subtype = false;
               $guid = null;
+
               if (count($segments) === 4) {
                 if (is_numeric($segments[3])) {
                   $guid = $segments[3];
@@ -190,6 +198,7 @@ function missions_main_page_handler($segments)
               $limit = $_GET['limit'];
               $resume = $_GET['resume'];
               $sort = isset($_GET['sort']);
+              $omit = $_GET['omit'];
               $export = new NRC\export(
                 $object_type,
                 $subtype,
@@ -198,9 +207,10 @@ function missions_main_page_handler($segments)
                 $before,
                 $limit,
                 $resume,
-                $sort
+                $sort,
+                $omit
               );
-              $export->getJSON();
+              $export->outputJSON();
             }
           }
           break;
@@ -235,14 +245,14 @@ function mission_set_url($hook, $type, $returnvalue, $params) {
 // Changes the view of the user entity if the context is 'mission'.
 function alter_mission_user_view($hook, $type, $returnvalue, $params) {
     $current_uri = $_SERVER['REQUEST_URI'];
-    
+
     if(strpos($current_uri, 'missions') === false) {
         return $returnvalue;
     }
     else {
-    	if(strpos($current_uri, 'missions/view') === false && 
-    			strpos($current_uri, 'missions/mission-invitation') === false && 
-    			strpos($current_uri, 'missions/mission-edit') === false && 
+    	if(strpos($current_uri, 'missions/view') === false &&
+    			strpos($current_uri, 'missions/mission-invitation') === false &&
+    			strpos($current_uri, 'missions/mission-edit') === false &&
     			strpos($current_uri, 'missions/mission-offer') === false) {
         	return elgg_view('user/mission-candidate', array('user' => $params['vars']['entity']));
     	}
@@ -260,11 +270,11 @@ function alter_mission_owner_block($hook, $type, $returnvalue, $params) {
     }
     else {
         $owner = elgg_get_page_owner_entity();
-        
+
         if ($owner instanceof ElggGroup || ($owner instanceof ElggUser && $owner->getGUID() != elgg_get_logged_in_user_guid())) {
             $header = '<h3>' . elgg_echo('missions:managed_by') . ':</h3>';
             $header .= elgg_view_entity($owner, array('full_view' => false));
-            
+
             return elgg_view('page/components/module', array(
                 'header' => $header,
                 'body' => '',

--- a/mod/missions/start.php
+++ b/mod/missions/start.php
@@ -199,6 +199,7 @@ function missions_main_page_handler($segments)
               $resume = $_GET['resume'];
               $sort = isset($_GET['sort']);
               $omit = $_GET['omit'];
+              $count = isset($_GET['count']);
               $export = new NRC\export(
                 $object_type,
                 $subtype,
@@ -208,7 +209,8 @@ function missions_main_page_handler($segments)
                 $limit,
                 $resume,
                 $sort,
-                $omit
+                $omit,
+                $count
               );
               $export->outputJSON();
             }


### PR DESCRIPTION
These are performance and minor feature upgrades to the recommendation provider API.

The API can now run under 64M, whereas before it required gigs to run due to how elgg performs queries internally; as well as how the objects were stored in memory before being converted to JSON.  Conversion is now done inline by the generator.

