### PR TITLE
limit community wire queries and remove pagination

### DIFF
--- a/mod/gc_communities/views/default/ajax/community_wire.php
+++ b/mod/gc_communities/views/default/ajax/community_wire.php
@@ -43,6 +43,8 @@ if (is_array($community_tags)) {
 	$query .= " AND wi.description LIKE '%{$community_tags}%'";
 }
 
+$query .= " LIMIT $wire_limit";
+
 $wire_ids = array();
 $wires = get_data($query);
 foreach ($wires as $wire) {
@@ -55,7 +57,7 @@ $options = array(
 	'limit' => $wire_limit,
 	'full_view' => false,
 	'list_type_toggle' => false,
-	'pagination' => true,
+	'pagination' => false,
 	'guids' => $wire_ids
 );
 

--- a/mod/gc_communities/views/default/page/layouts/index.php
+++ b/mod/gc_communities/views/default/page/layouts/index.php
@@ -146,6 +146,8 @@ if (!get_input('offset')) {
 		} else {
 			$query .= " AND wi.description LIKE '%{$community_tags}%'";
 		}
+		
+		$query .= " LIMIT $wire_limit";
 
 		$wire_ids = array();
 		$wires = get_data($query);
@@ -159,7 +161,7 @@ if (!get_input('offset')) {
 			'limit' => $wire_limit,
 			'full_view' => false,
 			'list_type_toggle' => false,
-			'pagination' => true,
+			'pagination' => false,
 			'guids' => $wire_ids
 		);
 

--- a/mod/gc_communities/views/default/widgets/filtered_wire_index/content.php
+++ b/mod/gc_communities/views/default/widgets/filtered_wire_index/content.php
@@ -32,6 +32,8 @@ if (is_array($widget_hashtag)) {
 	$query .= " AND wi.description LIKE '%{$widget_hashtag}%'";
 }
 
+$query .= " LIMIT $num_items";
+
 $wire_ids = array();
 $wires = get_data($query);
 foreach ($wires as $wire) {


### PR DESCRIPTION
It's one of the slowest queries on the platform if not limited.