### PR TITLE
Remove all member count

### DIFF
--- a/mod/gccollab_stats/pages/gccollab_stats/gccollab.php
+++ b/mod/gccollab_stats/pages/gccollab_stats/gccollab.php
@@ -292,7 +292,7 @@
                             type: 'bar'
                         },
                         title: {
-                            text: '<?php echo elgg_echo("gccollab_stats:types:title"); ?> (' + allMembersCount + ')'
+                            text: '<?php echo elgg_echo("gccollab_stats:types:title"); ?>
                         },
                         xAxis: {
                             type: 'category'


### PR DESCRIPTION
The all members count for the member type plot is incorrect. This pull request removes it from the title of the chart.