### PR TITLE
Remove tabs in member page

### DIFF
--- a/mod/members/start.php
+++ b/mod/members/start.php
@@ -104,13 +104,13 @@ function members_nav_popular($hook, $type, $returnvalue, $params) {
  * @param array  $params      unused
  * @return array
  */
-function members_nav_newest($hook, $type, $returnvalue, $params) {
-	$returnvalue['newest'] = array(
-		'title' => elgg_echo('sort:newest'),
-		'url' => "members/newest",
-	);
-	return $returnvalue;
-}
+// function members_nav_newest($hook, $type, $returnvalue, $params) {
+// 	$returnvalue['newest'] = array(
+// 		'title' => elgg_echo('sort:newest'),
+// 		'url' => "members/newest",
+// 	);
+// 	return $returnvalue;
+// }
 
 /**
  * Appends "online" tab to the navigation
@@ -121,13 +121,13 @@ function members_nav_newest($hook, $type, $returnvalue, $params) {
  * @param array  $params      unused
  * @return array
  */
-function members_nav_online($hook, $type, $returnvalue, $params) {
-	$returnvalue['online'] = array(
-		'title' => elgg_echo('members:label:online'),
-		'url' => "members/online",
-	);
-	return $returnvalue;
-}
+// function members_nav_online($hook, $type, $returnvalue, $params) {
+// 	$returnvalue['online'] = array(
+// 		'title' => elgg_echo('members:label:online'),
+// 		'url' => "members/online",
+// 	);
+// 	return $returnvalue;
+// }
 
 
 /**


### PR DESCRIPTION
For issue # https://zube.io/tbs-sct/gctools/c/4968

I put in comment code for removing Recent and online tabs. 
This is for test only. 

When we are sure we want to remove it, I will create a last commit to erase those commit.