### PR TITLE
Remove dashboard 

### DIFF
--- a/mod/wet4/start.php
+++ b/mod/wet4/start.php
@@ -78,8 +78,8 @@ function wet4_theme_init()
 
 	//register a page handler for friends
 	elgg_unregister_page_handler('friends'); //unregister core page handler
-	elgg_unregister_page_handler('dashboard'); //unregister dashboard handler to make our own
-	elgg_register_page_handler('dashboard', 'wet4_dashboard_page_handler');
+	//elgg_unregister_page_handler('dashboard'); //unregister dashboard handler to make our own
+	//elgg_register_page_handler('dashboard', 'wet4_dashboard_page_handler');
 	elgg_register_page_handler('friends', '_wet4_friends_page_handler'); //register new page handler for data tables
 	elgg_register_page_handler('friendsof', '_wet4_friends_page_handler');
 	elgg_register_page_handler('activity', 'activity_page_handler');


### PR DESCRIPTION
Related to https://zube.io/tbs-sct/gctools/c/4964

To remove dashboard, you can only turn off the plugin in the admin setting( plugins -> User Dashboard 1.9)
This will remove the option in the menu to access it. But, if an user as dashboard in his bookmarks or know the URL, he still can access it.

This pull request is to remove the possibility to access the dashboard by URL. 

Before merge this pull request, need to delete what add in comment and remove the function linked to "wet4_dashboard_page_handler" 