### PR TITLE
added /manifest.json as not requiring login

### DIFF
--- a/mod/loginrequired/start.php
+++ b/mod/loginrequired/start.php
@@ -73,6 +73,7 @@ function loginrequired_init() {
 	$allow[] = 'splash';
 	$allow[] = 'mod/contactform/';
 	$allow[] = 'thewire_image/download/.*';
+	$allow[] = 'manifest\.json';
 
 	if (getenv('SOLR_CRAWLER') != '' && $_SERVER['HTTP_USER_AGENT'] === getenv('SOLR_CRAWLER')){
 		$allow[] = '.*';


### PR DESCRIPTION
This is for: https://developer.mozilla.org/en-US/docs/Web/Manifest and should not require login to access.
It being redirected to login on every page load isn't helping anyone either.