### PR TITLE
Remove all site activity feed

### DIFF
--- a/engine/lib/river.php
+++ b/engine/lib/river.php
@@ -867,9 +867,6 @@ QUERY;
  * @access private
  */
 function _elgg_river_init() {
-	elgg_register_page_handler('activity', '_elgg_river_page_handler');
-	//$item = new \ElggMenuItem('activity', elgg_echo('activity'), 'activity');
-	//elgg_register_menu_item('site', $item);
 
 	elgg_register_widget_type('river_widget', elgg_echo('river:widget:title'), elgg_echo('river:widget:description'));
 

--- a/engine/lib/river.php
+++ b/engine/lib/river.php
@@ -868,8 +868,8 @@ QUERY;
  */
 function _elgg_river_init() {
 	elgg_register_page_handler('activity', '_elgg_river_page_handler');
-	$item = new \ElggMenuItem('activity', elgg_echo('activity'), 'activity');
-	elgg_register_menu_item('site', $item);
+	//$item = new \ElggMenuItem('activity', elgg_echo('activity'), 'activity');
+	//elgg_register_menu_item('site', $item);
 
 	elgg_register_widget_type('river_widget', elgg_echo('river:widget:title'), elgg_echo('river:widget:description'));
 

--- a/mod/wet4/start.php
+++ b/mod/wet4/start.php
@@ -82,7 +82,6 @@ function wet4_theme_init()
 	elgg_register_page_handler('dashboard', 'wet4_dashboard_page_handler');
 	elgg_register_page_handler('friends', '_wet4_friends_page_handler'); //register new page handler for data tables
 	elgg_register_page_handler('friendsof', '_wet4_friends_page_handler');
-	//elgg_register_page_handler('activity', 'activity_page_handler');
 	elgg_unregister_page_handler('messages');
 	elgg_register_page_handler('messages', 'wet4_messages_page_handler');
 

--- a/mod/wet4/start.php
+++ b/mod/wet4/start.php
@@ -82,7 +82,7 @@ function wet4_theme_init()
 	elgg_register_page_handler('dashboard', 'wet4_dashboard_page_handler');
 	elgg_register_page_handler('friends', '_wet4_friends_page_handler'); //register new page handler for data tables
 	elgg_register_page_handler('friendsof', '_wet4_friends_page_handler');
-	elgg_register_page_handler('activity', 'activity_page_handler');
+	//elgg_register_page_handler('activity', 'activity_page_handler');
 	elgg_unregister_page_handler('messages');
 	elgg_register_page_handler('messages', 'wet4_messages_page_handler');
 

--- a/pages/river.php
+++ b/pages/river.php
@@ -53,13 +53,6 @@ switch ($page_type) {
 		break;
 }
 
-// $activity = elgg_list_river($options);
-// if (!$activity) {
-// 	$activity = elgg_echo('river:none');
-// }
-
-//$content = elgg_view('core/river/filter', array('selector' => $selector));
-
 $sidebar = elgg_view('core/river/sidebar');
 
 $params = array(

--- a/pages/river.php
+++ b/pages/river.php
@@ -53,12 +53,12 @@ switch ($page_type) {
 		break;
 }
 
-$activity = elgg_list_river($options);
-if (!$activity) {
-	$activity = elgg_echo('river:none');
-}
+// $activity = elgg_list_river($options);
+// if (!$activity) {
+// 	$activity = elgg_echo('river:none');
+// }
 
-$content = elgg_view('core/river/filter', array('selector' => $selector));
+//$content = elgg_view('core/river/filter', array('selector' => $selector));
 
 $sidebar = elgg_view('core/river/sidebar');
 
@@ -70,6 +70,6 @@ $params = array(
 	'class' => 'elgg-river-layout',
 );
 
-$body = elgg_view_layout('content', $params);
+//$body = elgg_view_layout('content', $params);
 
 echo elgg_view_page($title, $body);


### PR DESCRIPTION
Related to https://zube.io/tbs-sct/gctools/c/4965

To remove all site activity feed we need to remove / comment some code outside of the mod repo.

We can only remove the link to the feed from the main menu, but user can still access the page if the type the url.

If we want to remove the entire page, we can only remove the body of the page so the user don't end up on a white page. The user still can access the menu to navigate somewhere else.

