### PR TITLE
Archived missions page need only join metadata tables once and using WHERE ... IN ()

### DIFF
--- a/mod/missions/pages/missions/archive.php
+++ b/mod/missions/pages/missions/archive.php
@@ -20,12 +20,8 @@ $options['type'] = 'object';
 $options['subtype'] = 'mission';
 $options['metadata_name_value_pairs'] = array(array(
 		'name' => 'state',
-		'value' => 'completed'
-), array(
-		'name' => 'state',
-		'value' => 'cancelled'
+		'value' => array('completed', 'cancelled')
 ));
-$options['metadata_name_value_pairs_operator'] = 'OR';
 $options['limit'] = 0;
 $entity_list = elgg_get_entities_from_metadata($options);
 


### PR DESCRIPTION
fixes #2040 

There's also the issue with all missions pages loading every single relevant mission server-side before applying pagination, but that's a broader issue.