### PR TITLE
chore: Pin Travis to trusty release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: php
+
+dist: trusty
+
 php:
  - 5.6
 


### PR DESCRIPTION
Related to #2072
This isn't a good/permanent solution, but stops the build from being perma-red