### PR TITLE
fixed pleio mod vendor directory going away with docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       - ./data/data:/data
       - /var/www/html/vendor
       - /var/www/html/docker
+      - /var/www/html/mod/pleio/vendor
     depends_on:
       - gcconnex-db
       # - nginx-proxy


### PR DESCRIPTION
pleio mod vendor directory exists and is needed, this will keep it that way when you docker-compose up so it should actually work that way now.