### PR TITLE
Adjust flexbox in event calendar title

### DIFF
--- a/mod/event_calendar/models/model.php
+++ b/mod/event_calendar/models/model.php
@@ -1418,7 +1418,7 @@ function event_calendar_get_page_content_list($page_type, $container_guid, $star
 
 
 	$params = event_calendar_generate_listing_params($page_type, $container_guid, $start_date, $display_mode, $filter, $region);
-	$title = $params['title2'];
+	$title = $params['title'];
 	$event_page = $params['event_page'];
 	$url = current_page_url();
 	if (substr_count($url, '?')) {
@@ -1855,11 +1855,9 @@ $logged_in_user = elgg_get_logged_in_user_entity();
 		$sidebar = "";
 	}
 elgg_push_breadcrumb($title);
-$title2 = elgg_view_title($title);
 
 	$params = array(
-		'title' => $title2,
-		'title2' => $title,
+		'title' => $title,
 		'content' => $content,
 		'other' => $other,
 		'context' => 'event_calendar',

--- a/mod/wet4/views/default/page/elements/title.php
+++ b/mod/wet4/views/default/page/elements/title.php
@@ -18,7 +18,7 @@ $page_owner = elgg_get_page_owner_entity();
 
 //Nick - if this content is in a group the group title will be the h1, the content title will be h2 as it is a child ofthe group
 if($page_owner instanceof ElggGroup){
-    echo "<h2 property='name' class=\"h3 title\">{$vars['title']}</h2>";
+    echo "<h2 property='name' class=\"h3 title\" style='flex:1'>{$vars['title']}</h2>";
 }else{
     echo "<h1 property='name' class='title'{$class}>{$vars['title']}</h1>";
 }


### PR DESCRIPTION
Flexbox in internet explorer is not working the same way as on chrome. Addind flexbox class to fix the overlap of the calendar over the action button when group of event calendar has a long title.

Fixing #2145 