### PR TITLE
Various Group CSS fixes

### DIFF
--- a/mod/gc_group_layout/views/default/css/group_layout.php
+++ b/mod/gc_group_layout/views/default/css/group_layout.php
@@ -51,10 +51,12 @@
    }
  }
 
+.groups-info {
+    flex-shrink: 8;
+}
+
  @media (max-width: 992px) {
-     .group-cover-photo{
-       height: 170px;
-   }
+
    .groups-profile{
        margin-top: 0px;
    }

--- a/mod/gc_group_layout/views/default/groups/profile/summary.php
+++ b/mod/gc_group_layout/views/default/groups/profile/summary.php
@@ -112,39 +112,7 @@ if (elgg_in_context('group_profile') || elgg_instanceof(elgg_get_page_owner_enti
 							}
 						?>
 						</div>
-
-						<div class="mrgn-bttm-sm pull-left mrgn-lft-lg">
-						<?php
-							if (strstr(strtolower($_SERVER['HTTP_USER_AGENT']), 'gsa-crawler') === false && strstr(strtolower($_SERVER['HTTP_USER_AGENT']), 'solr-crawler') === false) {
-								echo elgg_view('output/url', array(
-									'href' => "http://stats.gctools-outilsgc.ca/gcconnex?filter=".$group->guid,
-									'text' =>  elgg_echo('groups:stats'),
-									'is_trusted' => true,
-									'class' => '',
-								));
-							}
-						?>
-						</div>
 					</div>
-
-					<?php
-					//Add tags for new layout to profile stats
-					$profile_fields = elgg_get_config('group');
-					foreach ($profile_fields as $key => $valtype) {
-						$options = array('value' => $group->$key, 'list_class' => 'mrgn-bttm-sm',);
-						if ($valtype == 'tags') {
-							$options['tag_names'] = $key;
-							$tags .= elgg_view("output/$valtype", $options);
-						}
-					}
-					//check to see if tags have been made
-					//dont list tag header if no tags
-					if(!$tags){
-					} else {
-						if (strstr(strtolower($_SERVER['HTTP_USER_AGENT']), 'gsa-crawler') === false && strstr(strtolower($_SERVER['HTTP_USER_AGENT']), 'solr-crawler') === false)
-							echo '<div class="hidden-xs">'.$tags.'</div>';
-					}
-					?>
 				</div>
 			</div>
 

--- a/mod/gc_group_layout/views/default/groups/profile/tab_menu.php
+++ b/mod/gc_group_layout/views/default/groups/profile/tab_menu.php
@@ -44,6 +44,15 @@ if(elgg_get_context() == 'groupSubPage'){
     'priority' => '0',
     ));
 
+    elgg_register_menu_item('owner_block', array(
+        'name' => 'about2',
+        'href' => '/groups/about/' . $owner->getGUID(),
+        'text' => elgg_echo('gprofile:about'),
+        'item_class' => '',
+        'class' => '',
+        'priority' => '13',
+    ));
+
 } else if(elgg_get_context() == 'profile'){
     if ($pg == 'splashboard'){
 

--- a/mod/gc_group_layout/views/default/groups/sidebar/group_sidebar.php
+++ b/mod/gc_group_layout/views/default/groups/sidebar/group_sidebar.php
@@ -7,14 +7,32 @@ $format_description = '<div><b>'. elgg_echo('description').':</b></div>' . elgg_
 $link_to_about = elgg_view('output/url', array(
 	'text' => elgg_echo('group:more_button'),
 	'href' => '/groups/about/' .$group->guid,
-	'class' => 'btn btn-default',
+	'class' => 'btn btn-primary text-center center-block',
 ));
+
+$profile_fields = elgg_get_config('group');
+	foreach ($profile_fields as $key => $valtype) {
+		$options = array('value' => $group->$key, 'list_class' => 'mrgn-bttm-sm',);
+		if ($valtype == 'tags') {
+			$options['tag_names'] = $key;
+			$tags .= elgg_view("output/$valtype", $options);
+		}
+	}
+	//check to see if tags have been made
+	//dont list tag header if no tags
+	if(!$tags){
+	} else {
+		if (strstr(strtolower($_SERVER['HTTP_USER_AGENT']), 'gsa-crawler') === false && strstr(strtolower($_SERVER['HTTP_USER_AGENT']), 'solr-crawler') === false)
+			$format_tags = '<div class="hidden-xs">'.$tags.'</div>';
+	}
+
 $mem = ($group->isPublicMembership()) ? elgg_echo('groups:open') : elgg_echo('groups:closed');
 $access_list = elgg_format_element('li', ['class' => 'd-flex'], '<div class="info-title">'.elgg_echo('access').': </div><div>'. $mem.'</div>');
 $info_list = elgg_format_element('ul', ['class'=> 'mrgn-tp-md mrgn-bttm-0 list-unstyled group-info-list'], $access_list);
-$content = elgg_format_element('div', [], $info_list . $format_description . '<div class="mrgn-tp-md">' .$link_to_about. '</div>');
+$content = elgg_format_element('div', [], $info_list . $format_description . '<div class="mrgn-tp-md">' .$format_tags. '</div>');
 
 echo elgg_view('page/components/module', array(
 	'title' => elgg_echo('group:info'),
 	'body' => $content,
+	'footer' => $link_to_about,
 ));

--- a/mod/wet4/views/default/au_subgroups/sidebar/subgroups.php
+++ b/mod/wet4/views/default/au_subgroups/sidebar/subgroups.php
@@ -23,12 +23,12 @@ if (!$subgroups) {
 
 		$subgroup_name = gc_explode_translation( $subgroup->name, $lang);
 
-		$body .= elgg_view_image_block(
+		$body .= '<div class="mrgn-bttm-sm">'. elgg_view_image_block(
 				elgg_view_entity_icon($subgroup, 'tiny'), elgg_view('output/url', array(
 			'href' => $subgroup->getURL(),
 			'text' => $subgroup_name,
 			'is_trusted' => true))
-		);
+		) . '</div>';
 	}
 
     //count total number of subgroups and add it to view all link
@@ -41,10 +41,11 @@ $title = elgg_echo('au_subgroups:subgroups');
 $all_link = elgg_view('output/url', array(
 	'href' => 'groups/subgroups/list/' . $vars['entity']->guid,
 	'text' => elgg_echo('au_subgroups:subgroups:more') . $sgCount,
+	'class' => 'btn btn-default text-center center-block',
 	'is_trusted' => true,
 		));
 
-$footer = "<div class='text-right'>$all_link</div>";
+$footer = "<div>$all_link</div>";
 
 //only show subgroups widget if the group has subgroups
 if($sgCount){

--- a/mod/wet4/views/default/river/object/group/attachment.php
+++ b/mod/wet4/views/default/river/object/group/attachment.php
@@ -7,17 +7,17 @@ $object = $vars['item']->getObjectEntity();
 $thumbnail = elgg_view_entity_icon($object);
 // Member count may slow thins down
 // $num_members = $object->getMembers(array('count' => true));
-$group_access = get_readable_access_level($object->access_id);
+$member_status = ($object->isPublicMembership()) ? elgg_echo('groups:open') : elgg_echo('groups:closed');
 $title = elgg_format_element('a', ['href' => $object->getURL(), 'class' => 'h5 text-dark'], gc_explode_translation($object->name, $lang));
 
-$meta_info = elgg_format_element('div', [], '<div class="text-muted"><span class="ml-3">'.$group_access.'</span></div>');
+$meta_info = elgg_format_element('div', [], '<div class="text-muted"><span class="ml-3">'.$member_status.'</span></div>');
 
-$body = elgg_format_element('div', ['class'=> 'p-2'], '<div>'.$title.'</div>' .$meta_info);
+$body = elgg_format_element('div', ['class'=> 'p-2 pbm'], '<div>'.$title.'</div>' .$meta_info);
 
 //TODO grab the group cover photo is it exists
 echo <<<HTML
 <div class="border rounded river-group-object">
-  <div class="bg-primary w-100" style="height: 50px;"></div>
+  <div class="river-group-cover w-100" style="height: 50px;"></div>
   <div class="d-flex pl-4 pr-4 pb-4">
     <span class="river-group-avatar">$thumbnail</span>
     $body

--- a/mod/wet4/views/default/wet4_theme/custom_css.php
+++ b/mod/wet4/views/default/wet4_theme/custom_css.php
@@ -537,9 +537,20 @@ max-height: 500px;
   margin-right: 8px;
 }
 
+.river-group-object {
+    margin-top: 5px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+
 .river-group-object .river-group-avatar {
   margin: -25px 12px 12px 12px !important;
   background-color: white;
+}
+
+.river-group-cover {
+    background: -webkit-linear-gradient(left,#0d727a,#0d84b9);
+    background: linear-gradient(90deg,#0d727a 0,#0d84b9);
 }
 
 .river-group-avatar .au_subgroups_group_icon-medium-wet4 {

--- a/mod/wet4_collab/views/default/wet4_theme/custom_css.php
+++ b/mod/wet4_collab/views/default/wet4_theme/custom_css.php
@@ -1270,7 +1270,6 @@ a.wire-share-container:visited {
 
 .group-search-button{
     color: #46246A;
-
 }
 
 /*Color box - Nick */
@@ -1871,8 +1870,16 @@ figcaption{
 }
 
 .group-cover-photo{
-  background-color: #46246A !important;
+    background-color: #5197bf !important;
+    background-image: linear-gradient(270deg, #5197bf 0%, #46246a 100%) !important;
 }
+
+.group-summary-holder {
+    z-index: 2;
+    position: relative;
+    padding: 0 15px 20px;
+}
+
 .bar .progress-bar {
   background-color: #46246A !important;
 }
@@ -1920,6 +1927,17 @@ figcaption{
 
 .elgg-river-summary {
     padding-right: 45px;
+}
+
+.river-group-object {
+    margin-top: 5px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+
+.river-group-cover {
+    background-color: #5197bf !important;
+    background-image: linear-gradient(270deg, #5197bf 0%, #46246a 100%) !important;
 }
 
 .river-group-object .river-group-avatar {


### PR DESCRIPTION
- Group summary view modified to fix shrinking avatar
- Group cover photo no longer changes size at tablet view
- Group tags have been moved to the group information sidebar, the sidebar's more button has been given primary style
- Sub groups sidebar module style has been modified
- Group About tab menu item added (this is to help users navigate to the groups about page)
- Group river object has been styled and updated

fixes #2146 