### PR TITLE
Fixed wire shared content link on Newsfeed

### DIFF
--- a/mod/thewire_images/views/default/river/object/thewire/create.php
+++ b/mod/thewire_images/views/default/river/object/thewire/create.php
@@ -29,7 +29,8 @@ $summary = elgg_echo("river:create:object:thewire", array($subject_link, $object
 $attachments = "";
 $reshare = $object->getEntitiesFromRelationship(array("relationship" => "reshare", "limit" => 1));
 if (!empty($reshare)) {
-	$attachments = elgg_view("thewire_tools/reshare_source", array("entity" => $reshare[0]));
+	$reshare_object = elgg_view("thewire_tools/reshare_source", array("entity" => $reshare[0]));
+	$attachments = elgg_format_element('a', ['href' => $reshare[0]->getURL(), 'class' => 'river-wire-reshare timeStamp'], $reshare_object);
 }
 
 $attachment = thewire_image_get_attachments($object->getGUID());

--- a/mod/wet4/views/default/wet4_theme/custom_css.php
+++ b/mod/wet4/views/default/wet4_theme/custom_css.php
@@ -1348,7 +1348,15 @@ a.wire-share-container:visited {
     font-weight: bold;
     color: #137991;
 }
-
+a.river-wire-reshare {
+    width: 100%;
+    text-decoration: none;
+    display: block;
+}
+a.river-wire-reshare:hover {
+    text-decoration: underline;
+    color: #606060;
+}
 
 .img-tn{
     width:60px;

--- a/mod/wet4_collab/views/default/wet4_theme/custom_css.php
+++ b/mod/wet4_collab/views/default/wet4_theme/custom_css.php
@@ -1142,6 +1142,15 @@ a.wire-share-container:visited {
     font-weight: bold;
     color: #6b5088;
 }
+a.river-wire-reshare {
+    width: 100%;
+    text-decoration: none;
+    display: block;
+}
+a.river-wire-reshare:hover {
+    text-decoration: underline;
+    color: #606060;
+}
 
 .img-tn{
     width:60px;


### PR DESCRIPTION
Wire posts that appear on the newsfeed now properly link to the shared content.

Closes #2172 