### PR TITLE
Prep work for new freshdesk support portal

### DIFF
--- a/mod/freshdesk_help/pages/help.php
+++ b/mod/freshdesk_help/pages/help.php
@@ -1,4 +1,11 @@
 <?php
+
+	//redirect to new portal if set to gccollab
+	if(elgg_get_plugin_setting("product_id", "freshdesk_help") == 2100000290){
+		header("Location: https://support.gccollab.ca"); 
+		exit();
+	}
+
 	// Set context and title
 	elgg_set_context('freshdesk');
 

--- a/mod/freshdesk_help/pages/help.php
+++ b/mod/freshdesk_help/pages/help.php
@@ -1,8 +1,8 @@
 <?php
 
 	//redirect to new portal if set to gccollab
-	if(elgg_get_plugin_setting("product_id", "freshdesk_help") == 2100000290){
-		header("Location: https://support.gccollab.ca"); 
+	if(elgg_get_plugin_setting("custom_domain_url", "freshdesk_help")){
+		header("Location: " + elgg_get_plugin_setting("custom_domain_url", "freshdesk_help")); 
 		exit();
 	}
 

--- a/mod/freshdesk_help/start.php
+++ b/mod/freshdesk_help/start.php
@@ -16,9 +16,15 @@ function freshdesk_help_init() {
     elgg_extend_view("js/elgg", "js/freshdesk_help/functions");
     elgg_extend_view('css/elgg', 'freshdesk/css');
 
+    if(elgg_get_plugin_setting("product_id", "freshdesk_help") == 2100000290){
+        $help_link = "https://support.gccollab.ca";
+    } else {
+        $help_link = "help/knowledgebase";
+    }
+
     elgg_register_menu_item('site', array(
   		'name' => 'Help',
-      'href' => "help/knowledgebase",
+      'href' => $help_link,
       'text' => elgg_echo('freshdesk:page:title'),
       'priority' => 1000,
   	));

--- a/mod/freshdesk_help/start.php
+++ b/mod/freshdesk_help/start.php
@@ -16,8 +16,8 @@ function freshdesk_help_init() {
     elgg_extend_view("js/elgg", "js/freshdesk_help/functions");
     elgg_extend_view('css/elgg', 'freshdesk/css');
 
-    if(elgg_get_plugin_setting("product_id", "freshdesk_help") == 2100000290){
-        $help_link = "https://support.gccollab.ca";
+    if(elgg_get_plugin_setting("custom_domain_url", "freshdesk_help")){
+        $help_link = elgg_get_plugin_setting("custom_domain_url", "freshdesk_help");
     } else {
         $help_link = "help/knowledgebase";
     }

--- a/mod/freshdesk_help/views/default/plugins/freshdesk_help/settings.php
+++ b/mod/freshdesk_help/views/default/plugins/freshdesk_help/settings.php
@@ -40,6 +40,18 @@ echo '<label for="domain">Domain</label>';
 echo elgg_view("input/text", $params);
 echo '</div>';
 
+//domain
+$params = array(
+  'name' => 'params[custom_domain_url]',
+  'id' => 'custom_domain_url',
+  'class' => 'mrgn-bttm-sm',
+  'value' => $vars['entity']->custom_domain_url,
+);
+
+echo '<div class="basic-profile-field">';
+echo '<label for="custom_domain_url">Custom Domain URL</label>';
+echo elgg_view("input/text", $params);
+echo '</div>';
 
 //portal
 echo '<div class="basic-profile-field">';

--- a/mod/gccollab_theme/views/default/page/elements/footer.php
+++ b/mod/gccollab_theme/views/default/page/elements/footer.php
@@ -15,17 +15,17 @@ if ( strcmp(_elgg_services()->session->get('language'),'en') == 0 ) {
     $terms = "{$site_url}terms";
     $priv = "{$site_url}privacy";
 
-    $faq = "{$site_url}help/knowledgebase";
-
 } else {
     // french links (under about)
     $about = "{$site_url}a_propos";
     $terms = "{$site_url}termes";
     $priv = "{$site_url}confidentialite";
-
-    $faq = "{$site_url}help/knowledgebase";
 }
-
+if(elgg_get_plugin_setting("product_id", "freshdesk_help") == 2100000290){
+    $faq = "https://support.gccollab.ca";
+} else {
+    $faq = "{$site_url}help/knowledgebase1";
+}
 $feedbackText= elgg_echo('wet:feedbackText');
 
 ?>
@@ -62,7 +62,7 @@ $feedbackText= elgg_echo('wet:feedbackText');
                     <a href="<?php echo $faq;?>"><?php echo elgg_echo('wet:footFAQ');?></a>
                   </li>
                   <?php /*if(elgg_is_active_plugin('gc_onboard')){ echo '<li><a href="'.elgg_get_site_url().'tutorials">'.elgg_echo('onboard:footTutorials').'</a></li>'; }*/?>
-                  <li><a href="<?php echo elgg_get_site_url() . 'help/knowledgebase'; ?>"> <?php echo elgg_echo('contactform:help_menu_item'); ?> </a></li>
+                  <li><a href="<?php echo $faq; ?>"> <?php echo elgg_echo('contactform:help_menu_item'); ?> </a></li>
                    
                 </ul>
             </section>

--- a/mod/gccollab_theme/views/default/page/elements/footer.php
+++ b/mod/gccollab_theme/views/default/page/elements/footer.php
@@ -21,10 +21,10 @@ if ( strcmp(_elgg_services()->session->get('language'),'en') == 0 ) {
     $terms = "{$site_url}termes";
     $priv = "{$site_url}confidentialite";
 }
-if(elgg_get_plugin_setting("product_id", "freshdesk_help") == 2100000290){
-    $faq = "https://support.gccollab.ca";
+if(elgg_get_plugin_setting("custom_domain_url", "freshdesk_help")){
+    $faq = elgg_get_plugin_setting("custom_domain_url", "freshdesk_help");
 } else {
-    $faq = "{$site_url}help/knowledgebase1";
+    $faq = "{$site_url}help/knowledgebase";
 }
 $feedbackText= elgg_echo('wet:feedbackText');
 

--- a/mod/gcconnex_theme/views/default/page/elements/footer.php
+++ b/mod/gcconnex_theme/views/default/page/elements/footer.php
@@ -17,6 +17,13 @@ if (_elgg_services()->session->get('language') == 'en') {
 } else {
 	$graphic_lang = 'fr';
 }
+
+if(elgg_get_plugin_setting("custom_domain_url", "freshdesk_help")){
+    $faq = elgg_get_plugin_setting("custom_domain_url", "freshdesk_help");
+} else {
+    $faq = "{$site_url}help/knowledgebase";
+}
+$feedbackText= elgg_echo('wet:feedbackText');
 ?>
 <!-- This contains the bottom Footer Links -->
 <div class="container">
@@ -55,13 +62,7 @@ if (_elgg_services()->session->get('language') == 'en') {
 				</h3>
 				<ul class="list-unstyled">
 					<li>
-						<?php
-							if (elgg_is_active_plugin('freshdesk_help')) {
-								echo '<a href="'. elgg_get_site_url() . 'help/knowledgebase">'.elgg_echo('freshdesk:page:title').'</a>';
-							} else {
-								echo '<a href="'. elgg_get_site_url() . 'mod/contactform/">'.elgg_echo('contactform:help_menu_item').'</a>';
-							}
-						?>
+						<a href="<?php echo $faq; ?>"> <?php echo elgg_echo('contactform:help_menu_item'); ?> </a>
 					</li>
 				</ul>
 			</section>

--- a/mod/wet4/views/default/page/default.php
+++ b/mod/wet4/views/default/page/default.php
@@ -61,7 +61,11 @@ $userMenu = elgg_view('page/elements/topbar_wrapper', $vars);
 
 if (strstr(strtolower($_SERVER['HTTP_USER_AGENT']), 'gsa-crawler') === false && strstr(strtolower($_SERVER['HTTP_USER_AGENT']), 'solr-crawler') === false) {
 	if(elgg_is_active_plugin('freshdesk_help')){
-		$feedback_link = elgg_get_site_url().'/help/knowledgebase';
+		if(elgg_get_plugin_setting("custom_domain_url", "freshdesk_help")){
+			$feedback_link = elgg_get_plugin_setting("custom_domain_url", "freshdesk_help");
+		} else {
+			$feedback_link = elgg_get_site_url()."help/knowledgebase";
+		}
 	} else {
 		$feedback_link = elgg_get_site_url().'/mod/contactform';
 	}

--- a/mod/wet4_collab/views/default/page/default.php
+++ b/mod/wet4_collab/views/default/page/default.php
@@ -85,10 +85,10 @@ $userMenu = "";
 
 if (strstr(strtolower($_SERVER['HTTP_USER_AGENT']), 'gsa-crawler') === false) {
 	if(elgg_is_active_plugin('freshdesk_help')){
-		if(elgg_get_plugin_setting("product_id", "freshdesk_help") == 2100000290){
-			$feedback_link = "https://support.gccollab.ca";
+		if(elgg_get_plugin_setting("custom_domain_url", "freshdesk_help")){
+			$feedback_link = elgg_get_plugin_setting("custom_domain_url", "freshdesk_help");
 		} else {
-			$feedback_link = "help/knowledgebase";
+			$feedback_link = elgg_get_site_url()."help/knowledgebase";
 		}
 	} else {
 		$feedback_link = elgg_get_site_url().'mod/contactform/';

--- a/mod/wet4_collab/views/default/page/default.php
+++ b/mod/wet4_collab/views/default/page/default.php
@@ -85,7 +85,11 @@ $userMenu = "";
 
 if (strstr(strtolower($_SERVER['HTTP_USER_AGENT']), 'gsa-crawler') === false) {
 	if(elgg_is_active_plugin('freshdesk_help')){
-		$feedback_link = elgg_get_site_url().'help/knowledgebase/';
+		if(elgg_get_plugin_setting("product_id", "freshdesk_help") == 2100000290){
+			$feedback_link = "https://support.gccollab.ca";
+		} else {
+			$feedback_link = "help/knowledgebase";
+		}
 	} else {
 		$feedback_link = elgg_get_site_url().'mod/contactform/';
 	}


### PR DESCRIPTION
added support for custom portal to freshdesk plugin. If no custom domain is entered, the plugin defaults to help/knowledgebase url.