### PR TITLE
minor css fix to allow lists in discussion reply

### DIFF
--- a/mod/wet4_collab/views/default/wet4_theme/css.php
+++ b/mod/wet4_collab/views/default/wet4_theme/css.php
@@ -675,6 +675,10 @@ ol {
     list-style: none;
 }
 
+[data-role="discussion-reply-text"] li {
+    list-style: disc;
+}
+
 .list-inline {
   padding-left: 0;
   list-style: none;


### PR DESCRIPTION
small css tweak so that unordered lists appear in discussion reply's properly. Lists will still not appear properly in river calls. that should be made a separate issue