### PR TITLE
Discussion reply css fix

### DIFF
--- a/mod/wet4/views/default/wet4_theme/css.php
+++ b/mod/wet4/views/default/wet4_theme/css.php
@@ -676,7 +676,7 @@ ol {
 }
 
 [data-role="discussion-reply-text"] ul > li{
-    list-style: disc !important;
+    list-style: disc;
 }
 
 [data-role="discussion-reply-text"] ol > li{

--- a/mod/wet4/views/default/wet4_theme/css.php
+++ b/mod/wet4/views/default/wet4_theme/css.php
@@ -675,6 +675,14 @@ ol {
     list-style: none;
 }
 
+[data-role="discussion-reply-text"] ul > li{
+    list-style: disc !important;
+}
+
+[data-role="discussion-reply-text"] ol > li{
+    list-style: decimal;
+}
+
 .list-inline {
   padding-left: 0;
   list-style: none;

--- a/mod/wet4_collab/views/default/wet4_theme/css.php
+++ b/mod/wet4_collab/views/default/wet4_theme/css.php
@@ -676,7 +676,7 @@ ol {
 }
 
 [data-role="discussion-reply-text"] ul > li{
-    list-style: disc !important;
+    list-style: disc;
 }
 
 [data-role="discussion-reply-text"] ol > li{

--- a/mod/wet4_collab/views/default/wet4_theme/css.php
+++ b/mod/wet4_collab/views/default/wet4_theme/css.php
@@ -675,6 +675,10 @@ ol {
     list-style: none;
 }
 
+[data-role="discussion-reply-text"] li {
+    list-style: disc;
+}
+
 .list-inline {
   padding-left: 0;
   list-style: none;

--- a/mod/wet4_collab/views/default/wet4_theme/css.php
+++ b/mod/wet4_collab/views/default/wet4_theme/css.php
@@ -676,7 +676,7 @@ ol {
 }
 
 [data-role="discussion-reply-text"] ul > li{
-    list-style: disc;
+    list-style: disc !important;
 }
 
 [data-role="discussion-reply-text"] ol > li{

--- a/mod/wet4_collab/views/default/wet4_theme/css.php
+++ b/mod/wet4_collab/views/default/wet4_theme/css.php
@@ -675,8 +675,12 @@ ol {
     list-style: none;
 }
 
-[data-role="discussion-reply-text"] li {
+[data-role="discussion-reply-text"] ul > li{
     list-style: disc;
+}
+
+[data-role="discussion-reply-text"] ol > li{
+    list-style: decimal;
 }
 
 .list-inline {


### PR DESCRIPTION
added css so both ordered and unordered lists appear properly in discussion reply's. This will not fix display issues in river. A separate issue should be created for river. closes #2249 