### PR TITLE
Remove language toggle elements from file excerpt

### DIFF
--- a/mod/wet4/views/default/river/object/file/create.php
+++ b/mod/wet4/views/default/river/object/file/create.php
@@ -5,10 +5,11 @@
 $lang = get_current_language();
 $file = $vars['entity'];
 $object = $vars['item']->getObjectEntity();
-$excerpt = strip_tags($object->description);
+$excerpt = gc_explode_translation($object->description,$lang);
+$excerpt = strip_tags($excerpt);
 $excerpt = elgg_get_excerpt($excerpt);
 echo elgg_view('river/elements/layout', array(
   'item' => $vars['item'],
-  'message' => gc_explode_translation($excerpt,$lang),
+  'message' => $excerpt,
   'attachments' => elgg_view('river/object/file/attachment', array('item' => $vars['item'],)),
 ));


### PR DESCRIPTION
Files descriptions on activity feed will no longer show toggle language elements.

Closes #2271 