### PR TITLE
Allow special characters in titles

### DIFF
--- a/mod/wet4/lib/translate_display.php
+++ b/mod/wet4/lib/translate_display.php
@@ -53,7 +53,7 @@ function gc_explode_translation($imploded_txt, $lang)
         $value=$imploded_txt;
     }
 
-    return $value;
+    return htmlspecialchars_decode($value);
 }
 
 function old_gc_explode_translation($imploded_txt, $lang)


### PR DESCRIPTION
Modified explode translation function to allow special HTML characters to be rendered. 

Closes #2265 