### PR TITLE
Store token for later use on login

### DIFF
--- a/mod/pleio/pages/login.php
+++ b/mod/pleio/pages/login.php
@@ -121,6 +121,8 @@ if ($auth == 'oidc') {
         $session = elgg_get_session();
         $returnto = $session->get('last_forward_from');
 
+        $session->set('token', $oidc->getAccessToken());
+
         if ($returnto && pleio_is_valid_returnto($returnto)) {
             forward($returnto);
         } else {


### PR DESCRIPTION
To complete the PaaS integration into GCcollab, we will need the access token to send information back to PaaS. The token is now stored on login.