### PR TITLE
Fixed typo on help page redirect

### DIFF
--- a/mod/freshdesk_help/pages/help.php
+++ b/mod/freshdesk_help/pages/help.php
@@ -2,7 +2,7 @@
 
 	//redirect to new portal if set to gccollab
 	if(elgg_get_plugin_setting("custom_domain_url", "freshdesk_help")){
-		header("Location: " + elgg_get_plugin_setting("custom_domain_url", "freshdesk_help")); 
+		header("Location: " . elgg_get_plugin_setting("custom_domain_url", "freshdesk_help")); 
 		exit();
 	}
 


### PR DESCRIPTION
Fixed a typo that allows freshdesk_help plugin to redirect to the custom domain url that has been entered.

Closes #2295 