### PR TITLE
Upload avatar to PaaS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,12 @@ RUN apk --no-cache add \
   php5-zlib \
   php5-curl \
   curl
-RUN mkdir /app && mkdir /app/pleio && curl -sS https://getcomposer.org/installer | php5 -- --install-dir=/usr/local/bin --filename=composer
+RUN mkdir /app && mkdir /app/pleio && mkdir /app/paas_integration && curl -sS https://getcomposer.org/installer | php5 -- --install-dir=/usr/local/bin --filename=composer
 RUN ln -s /usr/bin/php5 /usr/bin/php
 WORKDIR /app
 COPY composer.json composer.json /app/
 COPY mod/pleio/composer.json /app/pleio/
+COPY mod/paas_integration/composer.json /app/paas_integration/
 
 ARG COMPOSER_ALLOW_SUPERUSER=1
 ARG COMPOSER_NO_INTERACTION=1
@@ -26,28 +27,31 @@ RUN composer install
 WORKDIR /app/pleio
 RUN composer install
 
+WORKDIR /app/paas_integration
+RUN composer install
+
 # Second stage, build usable container
 FROM alpine:3.7
 LABEL maintainer="Luc Belliveau <luc.belliveau@nrc-cnrc.gc.ca>, Ilia Salem"
 RUN \
   apk --no-cache add \
-    apache2 \
-    php5 \
-    php5-apache2 \
-    php5-ctype \
-    php5-curl \
-    php5-dom \
-    php5-gd \
-    php5-iconv \
-    php5-json \
-    php5-mysql \
-    php5-xml \
-	php5-zip \
-	php5-openssl \
-    php5-curl \
-    curl \
-    php5-opcache \
-    libmemcached-libs \
+  apache2 \
+  php5 \
+  php5-apache2 \
+  php5-ctype \
+  php5-curl \
+  php5-dom \
+  php5-gd \
+  php5-iconv \
+  php5-json \
+  php5-mysql \
+  php5-xml \
+  php5-zip \
+  php5-openssl \
+  php5-curl \
+  curl \
+  php5-opcache \
+  libmemcached-libs \
   && apk update \
   && apk --no-cache add php5-mysqli \
   && mkdir -p /var/www/html/vendor \
@@ -64,35 +68,36 @@ RUN \
   && sed -i '/<Directory "\/var\/www\/localhost\/htdocs">/c\<Directory "\/var\/www\/html">\nDirectoryIndex index.php\nOptions FollowSymLinks MultiViews\nAllowOverride All\nOrder allow,deny\nallow from all\n' /etc/apache2/httpd.conf
 
 RUN { \
-		echo 'opcache.memory_consumption=128'; \
-		echo 'opcache.interned_strings_buffer=8'; \
-		echo 'opcache.max_accelerated_files=4000'; \
-		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
-		echo 'opcache.enable_cli=1'; \
-		echo 'opcache.enable_file_override=1'; \
-} > /etc/php5/conf.d/opcache-recommended.ini
+  echo 'opcache.memory_consumption=128'; \
+  echo 'opcache.interned_strings_buffer=8'; \
+  echo 'opcache.max_accelerated_files=4000'; \
+  echo 'opcache.revalidate_freq=60'; \
+  echo 'opcache.fast_shutdown=1'; \
+  echo 'opcache.enable_cli=1'; \
+  echo 'opcache.enable_file_override=1'; \
+  } > /etc/php5/conf.d/opcache-recommended.ini
 
 # install memcached
 ENV PHPIZE_DEPS autoconf file g++ gcc libc-dev make pkgconf re2c php5-dev php5-pear \
- zlib-dev libmemcached-dev cyrus-sasl-dev libevent-dev openssl-dev
+  zlib-dev libmemcached-dev cyrus-sasl-dev libevent-dev openssl-dev
 ENV PHP_PEAR_PHP_BIN /usr/bin/php5
 RUN set -xe \
-    && apk add --no-cache \
-    --virtual .phpize-deps \
-    $PHPIZE_DEPS \
-    && sed -i 's/^exec $PHP -C -n/exec $PHP -C/g' $(which pecl) \
-    && pecl install memcache-2.2.7 \
-    && mv $(INSTALL_ROOT)/usr/lib/php5/modules/memcache.so /usr/lib/php5/modules/memcache.so \
-    && echo "extension=memcache.so" > /etc/php5/conf.d/memcache.ini \
-    && rm -rf /usr/share/php \
-    && rm -rf /tmp/* \
-    && apk del .phpize-deps
+  && apk add --no-cache \
+  --virtual .phpize-deps \
+  $PHPIZE_DEPS \
+  && sed -i 's/^exec $PHP -C -n/exec $PHP -C/g' $(which pecl) \
+  && pecl install memcache-2.2.7 \
+  && mv $(INSTALL_ROOT)/usr/lib/php5/modules/memcache.so /usr/lib/php5/modules/memcache.so \
+  && echo "extension=memcache.so" > /etc/php5/conf.d/memcache.ini \
+  && rm -rf /usr/share/php \
+  && rm -rf /tmp/* \
+  && apk del .phpize-deps
 
 COPY ./install/config/htaccess.dist /var/www/html/.htaccess
 COPY --from=0 /app/vendor/ /var/www/html/vendor/
 COPY . /var/www/html
 COPY --from=0 /app/pleio/vendor/ /var/www/html/mod/pleio/vendor/
+COPY --from=0 /app/paas_integration/vendor/ /var/www/html/mod/paas_integration/vendor/
 RUN chown apache:apache /var/www/html
 
 WORKDIR /var/www/html

--- a/mod/paas_integration/actions/avatar/upload.php
+++ b/mod/paas_integration/actions/avatar/upload.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Avatar upload action
+ */
+
+ // https://github.com/euautomation/graphql-client
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+use EUAutomation\GraphQL\Client;
+
+$guid = get_input('guid');
+$owner = get_entity($guid);
+
+if (!$owner || !($owner instanceof ElggUser) || !$owner->canEdit()) {
+	register_error(elgg_echo('avatar:upload:fail'));
+	forward(REFERER);
+}
+
+$error = elgg_get_friendly_upload_error($_FILES['avatar']['error']);
+if ($error) {
+	register_error($error);
+	forward(REFERER);
+}
+
+$icon_sizes = elgg_get_config('icon_sizes');
+
+// get the images and save their file handlers into an array
+// so we can do clean up if one fails.
+$files = array();
+foreach ($icon_sizes as $name => $size_info) {
+	$resized = get_resized_image_from_uploaded_file('avatar', $size_info['w'], $size_info['h'], $size_info['square'], $size_info['upscale']);
+
+	if ($resized) {
+		//@todo Make these actual entities.  See exts #348.
+		$file = new ElggFile();
+		$file->owner_guid = $guid;
+		$file->setFilename("profile/{$guid}{$name}.jpg");
+		$file->open('write');
+		$file->write($resized);
+		$file->close();
+		$files[] = $file;
+	} else {
+		// cleanup on fail
+		foreach ($files as $file) {
+			$file->delete();
+		}
+
+		register_error(elgg_echo('avatar:resize:fail'));
+		forward(REFERER);
+	}
+}
+
+// reset crop coordinates
+$owner->x1 = 0;
+$owner->x2 = 0;
+$owner->y1 = 0;
+$owner->y2 = 0;
+
+$owner->icontime = time();
+
+// Prepare for GraphQL query to PaaS
+
+$dbprefix = elgg_get_config("dbprefix");
+$service_url = elgg_get_plugin_setting("graphql_client", "paas_integration");
+$dev_url = elgg_get_plugin_setting("dev_url", "paas_integration");
+
+$session = elgg_get_session();
+$token = $session->get('token');
+
+$result = get_data_row("SELECT pleio_guid FROM {$dbprefix}users_entity WHERE guid = $guid");
+if ($result->pleio_guid) {
+	$gcID = $result->pleio_guid;
+}
+
+if($dev_url){
+	$site_url = $dev_url;
+} else {
+	$site_url = elgg_get_site_url();
+}
+
+$lastlogin = $owner->last_login;
+$joindate = $owner->time_created;
+
+$avatar = "$site_url/mod/profile/icondirect.php?guid=$guid&size=large&lastcache=$lastcache&joindate=$joindate";
+
+$client = new Client($service_url);
+
+$headers = [
+	"Authorization" => "Bearer $token"
+];
+
+$query = 'mutation ($gcID: ID!, $data: ModifyProfileInput!) {
+	modifyProfile(gcID: $gcID, data: $data) {
+		name
+		avatar
+	}
+}';
+
+$variables = array(
+	'gcID' => $gcID,
+	'data' => array(
+		'avatar' => $avatar
+	)
+);
+
+// Send data to PaaS
+$response = $client->response($query, $variables, $headers);
+
+error_log("///////////////////////////////////////////////////////////////////////////////////////////// ".serialize($response->errors()));
+error_log("///////////////////////////////////////////////////////////////////////////////////////////// ".$response->modifyProfile->avatar);
+error_log("\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\".serialize($response->all()));
+
+if (elgg_trigger_event('profileiconupdate', $owner->type, $owner)) {
+	system_message(elgg_echo("avatar:upload:success"));
+
+	$view = 'river/user/default/profileiconupdate';
+	elgg_delete_river(array('subject_guid' => $owner->guid, 'view' => $view));
+	elgg_create_river_item(array(
+		'view' => $view,
+		'action_type' => 'update',
+		'subject_guid' => $owner->guid,
+		'object_guid' => $owner->guid,
+	));
+}
+
+forward(REFERER);

--- a/mod/paas_integration/composer.json
+++ b/mod/paas_integration/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "gccollab/paas_integration",
+    "description": "This plugin contains libraries to integrate PaaS into GCcollab",
+    "type": "elgg-plugin",
+    "keywords": [
+        "elgg",
+        "plugin",
+        "oauth2",
+        "graphql"
+    ],
+    "license": "GPL-2.0",
+    "require": {
+        "euautomation/graphql-client": "^0.3.0"
+    }
+}

--- a/mod/paas_integration/manifest.xml
+++ b/mod/paas_integration/manifest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin_manifest xmlns="http://www.elgg.org/plugin_manifest/1.8">
+	<name>PaaS Integration</name>
+	<id>paas_integration</id>
+	<author>Government of Canada</author>
+	<version>1.0.0.0</version>
+	<description>Adds GraphQL queries / mutations to integrate with PaaS.</description>
+	<website>http://www.canada.ca</website>
+	<copyright>Her Majesty the Queen in Right of Canada, 2015</copyright>
+	<license>Creative Commons Attribution 3.0 Unported License</license>
+	<requires>
+		<type>elgg_release</type>
+		<version>1.12</version>
+	</requires>
+	
+	<activate_on_install>true</activate_on_install>
+</plugin_manifest>

--- a/mod/paas_integration/start.php
+++ b/mod/paas_integration/start.php
@@ -1,0 +1,9 @@
+<?php
+
+elgg_register_event_handler('init', 'system', 'paas_integration_init');
+
+function paas_integration_init() {
+
+    elgg_register_action("avatar/upload", elgg_get_plugins_path() . "paas_integration/actions/avatar/upload.php");
+    
+}

--- a/mod/paas_integration/views/default/core/avatar/crop.php
+++ b/mod/paas_integration/views/default/core/avatar/crop.php
@@ -1,0 +1,3 @@
+<?php 
+// Remove form
+?>

--- a/mod/paas_integration/views/default/core/avatar/upload.php
+++ b/mod/paas_integration/views/default/core/avatar/upload.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Avatar upload view
+ *
+ * @uses $vars['entity']
+ *
+ * GC_MODIFICATION
+ * Description: Adding avatar badge support / wet and bootstrap classes
+ * Author: GCTools Team
+ */
+
+//display avatar with badge
+$user_avatar = elgg_view_entity_icon($vars['entity'], 'large', array('use_hover' => false));
+
+$current_label = elgg_echo('avatar:current');
+
+$form_params = array('enctype' => 'multipart/form-data');
+$upload_form = elgg_view_form('avatar/upload', $form_params, $vars);
+
+?>
+
+<p class="mtm">
+	<?php echo elgg_echo('avatar:upload:instructions'); ?>
+</p>
+
+<?php
+
+$image = <<<HTML
+<div id="" class="mrl prl">
+	<label>$current_label</label><br />
+	$user_avatar
+</div>
+HTML;
+
+$body = <<<HTML
+<div id="">
+	$upload_form
+</div>
+HTML;
+
+//echo elgg_view_image_block($image, $upload_form);
+
+
+echo '<div class="col-sm-4 col-xs-12">' . $image . '</div>';
+echo '<div class="col-sm-8 col-xs-12">' . $body . '</div>';

--- a/mod/paas_integration/views/default/plugins/paas_integration/settings.php
+++ b/mod/paas_integration/views/default/plugins/paas_integration/settings.php
@@ -1,0 +1,35 @@
+<?php
+$plugin = $vars["entity"];
+
+echo "<p>";
+echo "<label>" . elgg_echo("PaaS Endpoint") . "<br />";
+echo elgg_view("input/text", array(
+    "id" => "graphql_client",
+    "name" => "params[graphql_client]",
+    "value" => $plugin->graphql_client
+));
+echo "</label>";
+echo "</p>";
+
+echo '<fieldset class="dev-settings">';
+echo '<legend>Developer Settings</legend>';
+
+echo "<p>";
+echo "<label>" . elgg_echo("Elgg Dev url") . "<br />";
+echo elgg_view("input/text", array(
+    "id" => "dev_url",
+    "name" => "params[dev_url]",
+    "value" => $plugin->dev_url,
+));
+echo "</label>";
+echo "</p>";
+echo '</fieldset>';
+?>
+
+<style>
+.dev-settings {
+    border: 1px solid black;
+    padding: 10px;
+    margin: 10px; 
+}
+</style>


### PR DESCRIPTION
Adds new plugin paas_integration to GCcollab to allow easy communication to PaaS. Set PaaS endpoint in admin settings of plugin and optionally set Dev url of current elgg instance.

When user uploads an avatar the action will now send the data in a mutation to PaaS.

Requires https://github.com/gctools-outilsgc/profile_service/pull/83