### PR TITLE
Maintain approval workflow with PaaS

### DIFF
--- a/mod/b_extended_profile_collab/languages/en.php
+++ b/mod/b_extended_profile_collab/languages/en.php
@@ -34,6 +34,8 @@ $english = array(
 
     'gcconnex_profile:about_me:access' => 'Who can see my description:',
 
+    'gcconnex_profile:approvals' => 'The following fields are awaiting approval on <a href="https://profile.gccollab.ca/">Directory</a> and may not reflect what has previously been entered.',
+
     // BASIC INFORMATION PROFILE FORM
     'gcconnex_profile:basic:name' => 'Name: ',
     'gcconnex_profile:basic:job' => 'Job Title EN: ',

--- a/mod/b_extended_profile_collab/languages/fr.php
+++ b/mod/b_extended_profile_collab/languages/fr.php
@@ -36,6 +36,8 @@ $french = array(
 
     'gcconnex_profile:about_me:access' => 'Accès aux renseignements à mon sujet : ',
 
+    'gcconnex_profile:approvals' => 'The following fields are awaiting approval on <a href="https://profile.gccollab.ca/">Directory</a> and may not reflect what has previously been entered.',
+
     // BASIC PROFILE FORM
     'gcconnex_profile:basic:name' => 'Nom : ',
     'gcconnex_profile:basic:job' => 'Titre : ',

--- a/mod/b_extended_profile_collab/views/default/profile/details.php
+++ b/mod/b_extended_profile_collab/views/default/profile/details.php
@@ -39,6 +39,22 @@ if ($user->canEdit()) {
     $fields_test = array('Name', 'Job', 'JobFr', 'Phone', 'Mobile');
     $new_address = array('streetAddress', 'city', 'province', 'postalcode', 'country');
 
+    // PaaS integration approvals
+    if(elgg_is_active_plugin('paas_integration')) {
+        $approvals = waiting_on_approval($user->guid);
+        if($approvals) {
+            echo '<div class="onboarding-cta-holder col-sm-12">';
+            echo '<p>'.elgg_echo('gcconnex_profile:approvals').'</p><ul>';
+            if($approvals['titleEn']){
+                echo '<li><a href="#job">'.elgg_echo('gcconnex_profile:basic:job').'</a></li>';
+            }
+            if($approvals['titleFr']){
+                echo '<li><a href="#jobfr">'.elgg_echo('gcconnex_profile:basic:jobfr').'</a></li>';
+            }
+            echo '</ul></div>';
+        }
+    }
+
     echo '<div class="row mrgn-bttm-md"><div class="col-sm-6"><h4 class="mrgn-tp-0">WIP DIRECTORY INFO</h4></div><div class="col-sm-6"><div class="pull-right"><span class="text-muted mrgn-rght-md">In sync with Directory </span><a href="#" role="button" class="btn btn-primary" target="_blank">Edit Profile in Directory</a></div></div></div>';
 
     $icon = elgg_view_entity_icon($user, $size, array(

--- a/mod/paas_integration/manifest.xml
+++ b/mod/paas_integration/manifest.xml
@@ -12,6 +12,10 @@
 		<type>elgg_release</type>
 		<version>1.12</version>
 	</requires>
+	<requires>
+        <type>plugin</type>
+        <name>pleio</name>
+    </requires>
 	
 	<activate_on_install>true</activate_on_install>
 </plugin_manifest>

--- a/mod/paas_integration/start.php
+++ b/mod/paas_integration/start.php
@@ -128,3 +128,54 @@ function edit_profile_paas_mutation($hook, $entity_type, $returnvalue, $params) 
 
     return null;
   }
+
+  function waiting_on_approval($guid){
+
+    $dbprefix = elgg_get_config("dbprefix");
+    $service_url = elgg_get_plugin_setting("graphql_client", "paas_integration");
+
+    $result = get_data_row("SELECT pleio_guid FROM {$dbprefix}users_entity WHERE guid = $guid");
+    if ($result->pleio_guid) {
+        $gcID = $result->pleio_guid;
+    }
+
+    $client = new Client($service_url);
+
+    $headers = [];
+
+    $query = 'query getYourApproval($gcIDSubmitter: gcIDProfileInput!) {
+        approvals(
+          gcIDSubmitter: $gcIDSubmitter,
+          status: Pending,
+          changeType: Informational,
+        ) {
+            id
+            requestedChange {
+                titleEn
+                titleFr
+            }
+        }
+    }';
+
+
+    $variables = array(
+        'gcIDSubmitter' => array(
+            'gcID' => $gcID
+        ),
+    );
+    
+    // Send data to PaaS
+    $response = $client->response($query, $variables, $headers);
+
+    // Error check
+    if($response->errors()){
+        return null;
+    } else if(!$response->approvals[0]->requestedChange) {
+        return null;
+    }
+
+    return array(
+        "titleEn" => $response->approvals[0]->requestedChange->titleEn,
+        "titleFr" => $response->approvals[0]->requestedChange->titleFr
+    );
+  }

--- a/mod/paas_integration/start.php
+++ b/mod/paas_integration/start.php
@@ -136,8 +136,9 @@ function edit_profile_paas_mutation($hook, $entity_type, $returnvalue, $params) 
 
     $result = get_data_row("SELECT pleio_guid FROM {$dbprefix}users_entity WHERE guid = $guid");
     if ($result->pleio_guid) {
-        $gcID = $result->pleio_guid;
+        return null;
     }
+    $gcID = $result->pleio_guid;
 
     $client = new Client($service_url);
 


### PR DESCRIPTION
When a user modifies their job titles, the profile page will now query PaaS to inform the user that they change is waiting on approval.

This notice can be found in the edit profile modal.