### PR TITLE
helm chart ingress / cert-manager fix

### DIFF
--- a/.chart/collab/templates/memcached-deployment.yaml
+++ b/.chart/collab/templates/memcached-deployment.yaml
@@ -27,9 +27,6 @@ spec:
               containerPort: 11211
               protocol: TCP
           resources:
-            requests:
-              memory: "64Mi"
-              cpu: "0.1"
             limits:
               memory: "96Mi"
-              cpu: "0.4"
+              cpu: "0.1"

--- a/.chart/collab/values.yaml
+++ b/.chart/collab/values.yaml
@@ -28,7 +28,7 @@ ingress:
   enabled: true
   annotations: 
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt
+    cert-manager.io/cluster-issuer: letsencrypt
     nginx.ingress.kubernetes.io/rewrite-target: /
   path: /
   tls:
@@ -79,14 +79,14 @@ env:
 ## Configure extra options for liveness and readiness probes
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
 livenessProbe:
-  enabled: true
+  enabled: false
   initialDelaySeconds: 300
   periodSeconds: 10
   timeoutSeconds: 5
   failureThreshold: 6
   successThreshold: 1
 readinessProbe:
-  enabled: true
+  enabled: false
   initialDelaySeconds: 30
   periodSeconds: 10
   timeoutSeconds: 2


### PR DESCRIPTION
 * updated cert-manager annotation, it's different now compared to older versions
 * liveness/readiness probes config isn't quite working so they will be disabled by default for now