### PR TITLE
Fix for advance search dropdown

### DIFF
--- a/mod/missions/languages/fr.php
+++ b/mod/missions/languages/fr.php
@@ -58,7 +58,7 @@ return array(
     "missions:time_commitment" =>"Période d'engagement",
     "missions:flexible" =>	"Flexible",
     "missions:specific" =>	"Spécifique",
-    "missions:work_remotely" =>	"Cette possibilité peut se faire  à distance",
+    "missions:work_remotely" =>	"Cette possibilité peut se faire à distance",
     "missions:opportunity_location" =>	"Lieu de la possibilité",
     "missions:security_level" =>	"Niveau de sécurité",
     "missions:language_requirements" =>	"Exigences linguistiques",


### PR DESCRIPTION
There was a second space in this string making it so the advance search could not match the drop down case.
Fixes #2383