### PR TITLE
Update Dockerfile for composer 2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ COPY mod/paas_integration/composer.json /app/paas_integration/
 
 ARG COMPOSER_ALLOW_SUPERUSER=1
 ARG COMPOSER_NO_INTERACTION=1
+RUN composer config --no-plugins allow-plugins.composer/installers true
 RUN composer install
 
 WORKDIR /app/pleio


### PR DESCRIPTION
Composer 2.2+ needs plugins to be explicitly allowed