### PR TITLE
check for init in start script as well

### DIFF
--- a/docker/start-alpine.sh
+++ b/docker/start-alpine.sh
@@ -6,6 +6,7 @@ then
 	echo "init detected for $INIT, running install script."
 	php5 /var/www/html/install/cli/docker_installer.php
 fi
+
 # Start server - depending on the image, one of these will work
 echo "Starting server"
 $@

--- a/docker/start-alpine.sh
+++ b/docker/start-alpine.sh
@@ -1,8 +1,11 @@
 #!/bin/sh
 
 # automated install
-php5 /var/www/html/install/cli/docker_installer.php
-
+if [ $INIT ]
+then
+	echo "init detected for $INIT, running install script."
+	php5 /var/www/html/install/cli/docker_installer.php
+fi
 # Start server - depending on the image, one of these will work
 echo "Starting server"
 $@

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
 
 # automated install
-php /var/www/html/install/cli/docker_installer.php
+if [ $INIT ]
+then
+	echo "init detected for $INIT, running install script."
+	php /var/www/html/install/cli/docker_installer.php
+fi
 
 # Start server - depending on the image, one of these will work
 echo "Starting server"


### PR DESCRIPTION
The install script also checks for specific values of $INIT, but this would filter out some unnecessary steps and log output for things like prod.