### PR TITLE
fix for search toggle keyboard accessibility

### DIFF
--- a/mod/gccollab_theme/views/default/page/elements/user_menu.php
+++ b/mod/gccollab_theme/views/default/page/elements/user_menu.php
@@ -85,8 +85,8 @@ if ( strstr(strtolower($_SERVER['HTTP_USER_AGENT']), 'gsa-crawler') !== false ||
 
         </li>
         <li class="elgg-menu-item-search">
-            <button type="button" class="btn btn-link" href="/search" title="Search" tabindex="0"> 
-                <span class="glyphicon-search glyphicon" data-toggle="collapse" data-target="#collapseSearch" aria-expanded="false" aria-controls="collapseSearch" style="color:#36013f"></span>
+            <button type="button" class="btn btn-link" href="/search" title="Search" tabindex="0" data-toggle="collapse" data-target="#collapseSearch" aria-expanded="false" aria-controls="collapseSearch"> 
+                <span class="glyphicon-search glyphicon" style="color:#36013f"></span>
             </button> 
         <?php 
 


### PR DESCRIPTION
It would only toggle on click otherwise even after you would select it with your mouse.
The tabindex issue still prevents you from actually getting to the search dropdown button normally in the first place, but the fix for that seems to involve making the user menu, etc. a separate nav menu instead of being nested under the site menu one.