### PR TITLE
initialize solr search mod for during dev install

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,10 +77,10 @@ services:
       - MYSQL_PASSWORD=gcconnex
 
 # this setup doesn't persist the index, you will need to run a re-index when restarting the container from http://gcconnex.local/admin/administer_utilities/solr_index
-#  gcconnex-solr:
-#    ports:
-#      - 8983:8983
-#    image: library/solr:6
-#    command: solr-precreate dev /dev-config
-#    volumes:
-#      - ./.solr-config:/dev-config/conf
+  gcconnex-solr:
+    ports:
+      - 8983:8983
+    image: library/solr:6
+    command: solr-precreate dev /dev-config
+    volumes:
+      - ./.solr-config:/dev-config/conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
       - SOLR_CRAWLER=solr-crawler-thing
 #	  - SOLR_CRAWLER_USER=1
       - E2E_TEST_INIT=true # if true, generates some content and use account for use in running tests, but may be useful for general dev too
+      - DEV_SOLR_HOST=gcconnex-solr
 
   # ###########################################################################
   # The GCConnex cron container.  This container is responsible for executing

--- a/install/cli/docker_install_additions/mods_init.php
+++ b/install/cli/docker_install_additions/mods_init.php
@@ -10,12 +10,21 @@ function init_mods_config(){
     init_site_menu();
     init_newsfeed_page_widgets();
     elgg_set_plugin_setting("custom_domain_url", "https://support.gccollab.ca", "freshdesk_help");  // this effectively changes the contact us link in the footer and site menu
+
+    init_elgg_solr();
 }
 
 function init_site_menu(){
     // this is the order that the menu items will appear in, 0 to 5, for 6 items max in total
     $featured_names = array(0 => "newsfeed", 1 => "career", 2 => "Colleagues", 3 => "groups", 4 => "Help");
     elgg_save_config('site_featured_menu_names', $featured_names);
+}
+
+function init_elgg_solr(){
+    elgg_set_plugin_setting("host", "gcconnex-solr", "elgg_solr");
+    elgg_set_plugin_setting("port", "8983", "elgg_solr");
+    elgg_set_plugin_setting("solr_path", "/solr/", "elgg_solr");
+    elgg_set_plugin_setting("solr_core", "dev", "elgg_solr");
 }
 
 function init_newsfeed_page_widgets(){

--- a/install/cli/docker_install_additions/mods_init.php
+++ b/install/cli/docker_install_additions/mods_init.php
@@ -6,13 +6,15 @@
  */
 
 
-function init_mods_config(){
+function init_mods_config($solr_host=''){
     init_site_menu();
     init_newsfeed_page_widgets();
     elgg_set_plugin_setting("custom_domain_url", "https://support.gccollab.ca", "freshdesk_help");  // this effectively changes the contact us link in the footer and site menu
 
     init_file_tools();
-    init_elgg_solr();
+
+    if ($solr_host != '')
+        init_elgg_solr($solr_host);
 }
 
 function init_site_menu(){
@@ -21,8 +23,10 @@ function init_site_menu(){
     elgg_save_config('site_featured_menu_names', $featured_names);
 }
 
-function init_elgg_solr(){
-    elgg_set_plugin_setting("host", "gcconnex-solr", "elgg_solr");
+function init_elgg_solr($solr_host){
+    if ($solr_host == "")
+        return false;
+    elgg_set_plugin_setting("host", $solr_host, "elgg_solr");
     elgg_set_plugin_setting("port", "8983", "elgg_solr");
     elgg_set_plugin_setting("solr_path", "/solr/", "elgg_solr");
     elgg_set_plugin_setting("solr_core", "dev", "elgg_solr");

--- a/install/cli/docker_install_additions/mods_init.php
+++ b/install/cli/docker_install_additions/mods_init.php
@@ -26,6 +26,8 @@ function init_elgg_solr(){
     elgg_set_plugin_setting("port", "8983", "elgg_solr");
     elgg_set_plugin_setting("solr_path", "/solr/", "elgg_solr");
     elgg_set_plugin_setting("solr_core", "dev", "elgg_solr");
+    elgg_set_plugin_setting("show_score", "yes", "elgg_solr");
+    elgg_set_plugin_setting("use_solr", "yes", "elgg_solr");
 }
 
 function init_file_tools(){

--- a/install/cli/docker_install_additions/mods_init.php
+++ b/install/cli/docker_install_additions/mods_init.php
@@ -11,6 +11,7 @@ function init_mods_config(){
     init_newsfeed_page_widgets();
     elgg_set_plugin_setting("custom_domain_url", "https://support.gccollab.ca", "freshdesk_help");  // this effectively changes the contact us link in the footer and site menu
 
+    init_file_tools();
     init_elgg_solr();
 }
 
@@ -25,6 +26,13 @@ function init_elgg_solr(){
     elgg_set_plugin_setting("port", "8983", "elgg_solr");
     elgg_set_plugin_setting("solr_path", "/solr/", "elgg_solr");
     elgg_set_plugin_setting("solr_core", "dev", "elgg_solr");
+}
+
+function init_file_tools(){
+    // this is the list of allowed extentions in prod
+    // the setting is empty by default on install and will prevent any file uploads until it's set to something
+    $allowed_extensions = "txt, jpg, jpeg, png, bmp, gif, pdf, doc, docx, xls, xlsx, ppt, pptx, odt, ods, odp, accdb, mdb, m4a, mp4, grd, map, rar, gdb, dwg, zip, mp3, ppsx, mid, mov, xlsm, ai, xd, svg, indd, vsd, vsdx, mpp, mppx, potx, dotx, .dotx, sas7bdat, dta, oft";
+    elgg_set_plugin_setting("allowed_extensions", $allowed_extensions, "file_tools");
 }
 
 function init_newsfeed_page_widgets(){

--- a/install/cli/docker_installer.php
+++ b/install/cli/docker_installer.php
@@ -117,8 +117,10 @@ echo "Elgg CLI install successful. wwwroot: " . elgg_get_config('wwwroot') . "\n
 
 // arrange and activate mods
 init_mods( $type );
+
 // some mods require some configuration to work as expected, do that now
-init_mods_config();
+$solr_host = (getenv('DEV_SOLR_HOST') ? getenv('DEV_SOLR_HOST') : '');
+init_mods_config($solr_host);
 
 echo "Elgg CLI plugin install successful. \n";
 


### PR DESCRIPTION
this will automatically set up and configure a solr instance and point the solr mod at it during a local dev install. Will need some more work to have this set up for review sites.
While testing this I was reminded that allowed file extensions don't get initialized properly by default, so there's an initialization for that too now.