### PR TITLE
Adjusted startup command to run a shell script to start memcached and…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,4 +96,4 @@ RUN chmod +x docker/start.sh
 # Start Apache in foreground mode
 RUN rm -f /run/apache2/httpd.pid
 ENTRYPOINT [ "docker/start.sh" ]
-CMD  ["apache2ctl -D FOREGROUND"]
+CMD  ["./docker/wrapper_script.sh"]

--- a/docker/run_apache
+++ b/docker/run_apache
@@ -1,0 +1,1 @@
+apache2ctl -D FOREGROUND

--- a/docker/run_memcached
+++ b/docker/run_memcached
@@ -1,0 +1,1 @@
+/etc/init.d/memcached start

--- a/docker/wrapper_script.sh
+++ b/docker/wrapper_script.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# turn on bash's job control
+set -m
+
+# Apache is the primary process
+./docker/run_apache &
+
+# Memcached is the second process
+
+./docker/run_memcached
+
+# Bring the primary process back to foreground
+
+fg %1


### PR DESCRIPTION
… apache
Not sure if it's the most efficient way to ensure the process starts with the container, but it's working.
![image](https://github.com/gctools-outilsgc/gcconnex/assets/17506947/366c16e1-bbb0-4eab-9a25-e4c7c64744a2)


Based on: 

https://docs.docker.com/config/containers/multi-service_container/
