### PR TITLE
apache level path based request blocking for non-k8s environments

### DIFF
--- a/docker/000-default.conf
+++ b/docker/000-default.conf
@@ -16,6 +16,6 @@
 	<Location /cometchat>
             Order allow,deny
             deny from all
-	</Location
+	</Location>
 
 </VirtualHost>

--- a/docker/000-default.conf
+++ b/docker/000-default.conf
@@ -12,5 +12,10 @@
             allow from all
             Require all granted
     </Directory>
+	
+	<Location /cometchat>
+            Order allow,deny
+            deny from all
+	</Location
 
 </VirtualHost>


### PR DESCRIPTION
block /cometchat, though I don't really expect it to still be a problem. When we first removed this feature with to be replaced with a separate app, the constant requests were not being handled well by elgg's 404, hence the block.