### PR TITLE
internal tool federated search error potential fix

### DIFF
--- a/mod/gcconnex_theme/views/default/search/search_box.php
+++ b/mod/gcconnex_theme/views/default/search/search_box.php
@@ -53,7 +53,7 @@ $selected_language = ($gc_language === '' || $gc_language === 'en' || !$gc_langu
 			<label for="wb-srch-q" class="wb-inv"> <?php echo elgg_echo('wet:searchweb'); ?> </label>
 			<input class="wb-srch-q form-control" name="q" onkeypress="handleKeyPress(event)" value="" size="21" maxlength="150" placeholder="<?php echo $placeholder ?>" id="wb-srch-q">
 			<input type="hidden" id="a" name="a" value="s">
-			<input type="hidden" id="s" name="s" value="3">
+			<input type="hidden" id="s" name="s" value="1">
 			<input type="hidden" id="chk4" name="chk4" value="on">
 		</div>
 		<div class="form-group submit">


### PR DESCRIPTION
the solr federated search page suddenly started throwing errors, changing s=3  to s=1 seems to fix it.
The search page does however end up looking like the intranet one, the the gcconnex-themed one (the s parameter is for the theme it seems).

If this gets fixed on the search page then we can revert this change, however if this persists long-term we should make the same change on the gcpedia one as well.