### PR TITLE
Preparing PR instances for sharing the environment with wiki instances

### DIFF
--- a/.bicep/PR/collab-test-instance.bicep
+++ b/.bicep/PR/collab-test-instance.bicep
@@ -23,7 +23,7 @@ var imageRepoName = toLower('collab_${prName}')
 var linuxFxVersion = empty(containerSHA) ? 'DOCKER|${acrName}.azurecr.io/${imageRepoName}:${containerTag}' : 'DOCKER|${acrName}.azurecr.io/${imageRepoName}@sha256:${containerSHA}'
 
 var appName = 'gccollab-dev-${prName}'
-var dbName = 'gccollab-dev-db-${prName}'
+var dbName = 'gccollab-${prName}'
 var nodash_nounderscore_tag = replace(replace(prName, '-', ''), '_', '')
 var storagePrefix = toLower( (length(nodash_nounderscore_tag)) > 12 ? substring('devgcccollab${nodash_nounderscore_tag}', 0, 24) : 'devgcccollab${nodash_nounderscore_tag}' )
 
@@ -74,7 +74,7 @@ resource webApp 'Microsoft.Web/sites@2022-03-01' = {
         }
         {
           name: 'DBNAME'
-          value: prName
+          value: dbName
         }
         {
           name: 'DATAROOT'
@@ -131,7 +131,7 @@ module db './modules/db_existing_server.bicep' = {
   scope: resourceGroup(dbServerRG)
   params: {
     dbServerName: dbServerName
-    dbName: prName
+    dbName: dbName
   }
 }
 

--- a/azure-pipelines-PR-cleanup.yaml
+++ b/azure-pipelines-PR-cleanup.yaml
@@ -36,6 +36,7 @@ steps:
               echo "$pr_number cleanup"
               az group delete --name collab_review_$pr_number --yes
               az mariadb db delete -g $DBRG -s $DBSERVERNAME --name pr-$pr_number --yes
+              az mariadb db delete -g $DBRG -s $DBSERVERNAME --name gccollab-pr-$pr_number --yes
               az acr repository delete --name $ACR_NAME --repository collab_pr-$pr_number --yes
           fi
       done


### PR DESCRIPTION
This is to try sharing the common PR instance common services between wiki and collab by specifying which one the db belongs to, will also help differentiate between collab vs. connex and wiki vs. gcpedia DBs, etc. when we get to that.