### PR TITLE
adds an option to disable notifications for new non-missions content

### DIFF
--- a/mod/cp_notifications/languages/en.php
+++ b/mod/cp_notifications/languages/en.php
@@ -5,6 +5,7 @@ $site_name = $site->name;
 $contact_us = "{$site->getURL()}mod/contactform/?utm_source=notification_digest&utm_medium=email";
 
 $english = array(
+	'cp_newsletter:NO_content_notifications' => "New content notifications is disabled, use the digest or newsfeed",
 
 	'cp_notification:group_invite' => "<p>%s</p><p>Click the following link to view your invitation (you must be logged in to view this page): %s</p>
 	<p>Need help? See the article '<a href='%s'>How to join a group?</a>' or <a href='%s'>contact us</a></p>",

--- a/mod/cp_notifications/languages/fr.php
+++ b/mod/cp_notifications/languages/fr.php
@@ -5,6 +5,7 @@ $site_name = $site->name;
 $contact_us = "{$site->getURL()}mod/contactform/";
 
 $french = array( 
+	'cp_newsletter:NO_notent_notifications' => "Les notifications des contenus nouveaux sont désactivées, utilisez le résumé ou le fil des nouvelle",
 
 	'cp_notification:group_invite' => "<p>%s</p><p>Cliquez le lien suivant pour consulter votre invitation (vous devez être connecté pour voir cette page) : %s</p>
 	<p>Besoin d'aide? Voir l’article « <a href='%s'>Comment joindre un groupe</a> » ou <a href='%s'>contactez-nous</a></p>",

--- a/mod/cp_notifications/start.php
+++ b/mod/cp_notifications/start.php
@@ -1441,7 +1441,7 @@ function cp_create_notification($event, $type, $object) {
 					if (strcmp($user_setting, "set_digest_yes") == 0) {
 						create_digest($author, $switch_case, $content_entity, get_entity($to_recipient->guid));
 				
-					} else {
+					} else if ( elgg_get_plugin_setting( 'cp_notifications_disable_content_notifications', 'cp_notifications' ) != 'yes' || $switch_case == 'mission' ) {
 				
 						$template = elgg_view('cp_notifications/email_template', $message);
 				
@@ -1457,7 +1457,7 @@ function cp_create_notification($event, $type, $object) {
 	}
 
 	/// send site notifications
-	if (is_array($to_recipients_site)) {
+	if (is_array($to_recipients_site) && (elgg_get_plugin_setting( 'cp_notifications_disable_content_notifications', 'cp_notifications' )  != 'yes' || $switch_case == 'mission') ) {
 		
 		foreach ($to_recipients_site as $to_recipient) {
 			$user_setting = elgg_get_plugin_user_setting('cpn_set_digest', $to_recipient->guid, 'cp_notifications');

--- a/mod/cp_notifications/views/default/forms/notifications/usersettings.php
+++ b/mod/cp_notifications/views/default/forms/notifications/usersettings.php
@@ -20,6 +20,7 @@ $title = elgg_echo('cp_notifications:heading:page_title');
 
 
 $content .= "<input type='text' style='visibility:hidden' name='user_guid' value='".$user->getGUID()."'> ";
+$content .= "<div class='warning alert-warning col-sm-12'><p>".elgg_echo('cp_newsletter:NO_content_notifications')."</p></div>";
 
 /// DIGEST OPTION FOR USER NOTIFICATIONS
 $enable_digest = elgg_get_plugin_setting('cp_notifications_enable_bulk','cp_notifications');

--- a/mod/cp_notifications/views/default/forms/notifications/usersettings.php
+++ b/mod/cp_notifications/views/default/forms/notifications/usersettings.php
@@ -20,7 +20,10 @@ $title = elgg_echo('cp_notifications:heading:page_title');
 
 
 $content .= "<input type='text' style='visibility:hidden' name='user_guid' value='".$user->getGUID()."'> ";
-$content .= "<div class='warning alert-warning col-sm-12'><p>".elgg_echo('cp_newsletter:NO_content_notifications')."</p></div>";
+
+if (strcmp(elgg_get_plugin_setting('cp_notifications_disable_content_notifications','cp_notifications'), 'yes') == 0) {
+	$content .= "<div class='warning alert-warning col-sm-12'><p>".elgg_echo('cp_newsletter:NO_content_notifications')."</p></div>";
+}
 
 /// DIGEST OPTION FOR USER NOTIFICATIONS
 $enable_digest = elgg_get_plugin_setting('cp_notifications_enable_bulk','cp_notifications');

--- a/mod/cp_notifications/views/default/plugins/cp_notifications/settings.php
+++ b/mod/cp_notifications/views/default/plugins/cp_notifications/settings.php
@@ -23,6 +23,9 @@ if (!isset($vars['entity']->cp_notifications_sidebar))
 if (!isset($vars['entity']->cp_enable_minor_edit))
 	$vars['entity']->cp_enable_minor_edit = 'no';
 
+if (!isset($vars['entity']->cp_notifications_disable_content_notifications))
+	$vars['entity']->cp_notifications_disable_content_notifications = 'no';
+
 
 $body = "<br/>";
 
@@ -87,6 +90,16 @@ $body .=  elgg_view('input/select', array(
 	'name' => 'params[cp_enable_minor_edit]',
 	'options_values' => array( 'no' => elgg_echo('option:no'), 'yes' => elgg_echo('option:yes') ),
 	'value' => $vars['entity']->cp_enable_minor_edit,
+));
+
+$body .= "<br/><br/>";
+
+// disable new content notifications
+$body .= "<label> DISABLE all new content notifications, excluding careers marketplace </label>";
+$body .= elgg_view('input/select', array(
+	'name' => 'params[cp_notifications_disable_content_notifications]',
+	'options_values' => array( 'no' => elgg_echo('option:no'), 'yes' => elgg_echo('option:yes')	),
+	'value' => $vars['entity']->cp_notifications_disable_content_notifications,
 ));
 
 $body .= "<br/><br/>";


### PR DESCRIPTION
Making this a more formal option, since the way notifications are coded right now can cause serious slowdowns and timeouts, so even outside the gcconnex decommission context this might be useful to have as an option.

Added a placeholder message for the notification settings page since that seems like a reasonable place to mention if this has been activated.

closes  #2677 