### PR TITLE
download discussion export proof of concept

### DIFF
--- a/mod/group_tools/lib/hooks.php
+++ b/mod/group_tools/lib/hooks.php
@@ -446,6 +446,13 @@ function group_tools_menu_entity_handler($hook, $type, $return_value, $params) {
 				"item_class" => ($entity->status == "closed") ? "" : "hidden"
 			));
 			$result[] = ElggMenuItem::factory(array(
+				"name" => "download_full_discussion",
+				"text" => '<span class="fa fa-download fa-lg icon-unsel"><span class="wb-inv">Open</span></span>',
+				"href" => "download_full_discussion/" . $entity->getGUID(),
+				"title" => elgg_echo("download_full_discussion"),
+				"priority" => 202
+			));
+			$result[] = ElggMenuItem::factory(array(
 				"name" => "status_change_close",
 				"text" => '<span class="fa fa-unlock fa-lg icon-unsel"><span class="wb-inv">Close</span></span>', //elgg_echo("close");,
 				"confirm" => elgg_echo("group_tools:discussion:confirm:close"),

--- a/mod/group_tools/start.php
+++ b/mod/group_tools/start.php
@@ -175,6 +175,42 @@ function group_tools_init() {
 	elgg_register_action("group_tools/order_groups", dirname(__FILE__) . "/actions/order_groups.php", "admin");
 	
 	elgg_register_action("discussion/toggle_status", dirname(__FILE__) . "/actions/discussion/toggle_status.php");
+	elgg_register_page_handler('download_full_discussion', 'download_full_discussion');
+}
+
+function download_full_discussion($page){
+	$guid = $page[0];
+	$topic = get_entity($guid);
+	$title = gc_explode_translation($topic->title, 'en');
+	$replies = elgg_get_entities(array(
+		"type" => "object",
+		"subtype" => "discussion_reply",
+		"container_guid" => $topic->getGUID(),
+		"count" => false,
+	));
+
+	$file = "";
+
+	$file .= "discussion ID: $guid \n";
+	$file .= "Title: $title \n";
+	$file .= gc_explode_translation($topic->description, 'en') . "\n";
+	$file .= "------\n";
+
+	foreach ($replies as $reply) {
+		$user = get_entity($reply->owner_guid);
+		$file .= "{$user->username}:\n {$reply->description} \n---\n";
+	}
+
+	$mime = "application/octet-stream";
+	header("Pragma: public");
+
+	header("Content-type: $mime");
+	header("Content-Disposition: attachment; filename=\"$title.txt\"");
+	flush();
+	echo $file;
+	exit;
+
+	return 1;
 }
 
 /**


### PR DESCRIPTION
Adds a download icon button to discussions including in list view, generates a simple dump with minimal formatting to make it a bit more intelligible that is downloaded as a txt file.