### PR TITLE
Export group email list functionality for group admins

### DIFF
--- a/mod/gc_export/languages/en.php
+++ b/mod/gc_export/languages/en.php
@@ -2,6 +2,7 @@
 
 	$english = array(
 		'decommission:discussion:export' => 'Export the Discussion',
+		'decommission:email_list' => 'Members Email List'
 	);
 
 	add_translation("en", $english);

--- a/mod/gc_export/languages/fr.php
+++ b/mod/gc_export/languages/fr.php
@@ -2,6 +2,7 @@
 
 	$french = array(
 		'decommission:discussion:export' => 'Exporter la discussion',
+		'decommission:email_list' => 'Liste de courriels des membres'
 	);
 
 	add_translation("fr", $french);

--- a/mod/gc_export/start.php
+++ b/mod/gc_export/start.php
@@ -79,17 +79,15 @@ function download_full_discussion($page){
 function group_email_list_setup_menu() {
 	$page_owner = elgg_get_page_owner_entity();
 
-	if (elgg_in_context('groups')) {
-		if ($page_owner instanceof ElggGroup) {
-			if (elgg_is_logged_in() && $page_owner->canEdit()) {
-				$url = elgg_get_site_url() . "download_group_emails/{$page_owner->getGUID()}";
-				elgg_register_menu_item('group_ddb', array(
-					'name' => 'email_export',
-					'text' => elgg_echo('decommission:email_list'),
-					'href' => $url,
-					"priority" => 500,
-				));
-			}
+	if ($page_owner instanceof ElggGroup) {
+		if (elgg_is_logged_in() && $page_owner->canEdit()) {
+			$url = elgg_get_site_url() . "download_group_emails/{$page_owner->getGUID()}";
+			elgg_register_menu_item('group_ddb', array(
+				'name' => 'email_export',
+				'text' => elgg_echo('decommission:email_list'),
+				'href' => $url,
+				"priority" => 500,
+			));
 		}
 	}
 }
@@ -99,7 +97,12 @@ function download_group_emails($page){
 		return 0;
 	gatekeeper();
 
-	if (!get_entity($page[0])->canEdit()) {
+	$entity = get_entity($page[0]);
+	if (!($entity instanceof ElggGroup)) {
+		register_error(elgg_echo('decommission:notgroup'));
+		forward(REFERER);
+	}
+	if (!$entity->canEdit()) {
 		register_error(elgg_echo('decommission:notgroupadmin'));
 		forward(REFERER);
 	}

--- a/mod/gc_export/start.php
+++ b/mod/gc_export/start.php
@@ -11,11 +11,15 @@ require_once(dirname(__FILE__) . "/lib/hooks.php");
 
 function gcexport_init() {
     elgg_register_plugin_hook_handler("register", "menu:entity", "discussion_menu_entity_hook");
+    elgg_register_event_handler('pagesetup', 'system', 'group_email_list_setup_menu');
     elgg_register_page_handler('download_full_discussion', 'download_full_discussion');
+    elgg_register_page_handler('download_group_emails', 'download_group_emails');
 }
 
 
 function download_full_discussion($page){
+	if (!is_numeric($page[0]))
+		return 0;
 	$guid = $page[0];
 	$topic = get_entity($guid);
 	$title = html_entity_decode(gc_explode_translation($topic->title, 'en')) . " | " . html_entity_decode(gc_explode_translation($topic->title, 'fr'));
@@ -67,6 +71,51 @@ function download_full_discussion($page){
 	flush();
 	echo $file;
 	exit;
+
+	return 1;
+}
+
+
+function group_email_list_setup_menu() {
+	$page_owner = elgg_get_page_owner_entity();
+
+	if (elgg_in_context('groups')) {
+		if ($page_owner instanceof ElggGroup) {
+			if (elgg_is_logged_in() && $page_owner->canEdit()) {
+				$url = elgg_get_site_url() . "download_group_emails/{$page_owner->getGUID()}";
+				elgg_register_menu_item('group_ddb', array(
+					'name' => 'email_export',
+					'text' => elgg_echo('decommission:email_list'),
+					'href' => $url,
+					"priority" => 500,
+				));
+			}
+		}
+	}
+}
+
+function download_group_emails($page){
+	if (!is_numeric($page[0]))
+		return 0;
+	gatekeeper();
+
+	if (!get_entity($page[0])->canEdit()) {
+		register_error(elgg_echo('decommission:notgroupadmin'));
+		forward(REFERER);
+	}
+
+	$group_guid = $page[0];
+
+	$dbprefix = elgg_get_config('dbprefix');
+	$query = "SELECT u.email AS email FROM  {$dbprefix}entity_relationships r, {$dbprefix}users_entity u WHERE r.guid_one = u.guid AND r.relationship = 'member' AND r.guid_two = $group_guid";
+
+	$user_emails = get_data($query);
+
+	$list = "";
+	foreach ($user_emails as $email) {
+		$list .= "$email->email <br />\n";
+	}
+	echo $list;
 
 	return 1;
 }


### PR DESCRIPTION
User owners and operators will be able to get a list of user emails, useful for when the email members functionality crashes due to too many members, this should work for groups with up to 50 000 users without optimizations to reduce memory usage.