### PR TITLE
poll view will now  always only show poll results in read only mode

### DIFF
--- a/mod/gcconnex_read_only/views/default/polls/poll_widget_content.php
+++ b/mod/gcconnex_read_only/views/default/polls/poll_widget_content.php
@@ -1,0 +1,14 @@
+<?php
+elgg_load_library('elgg:polls');
+
+$poll = elgg_extract('entity', $vars);
+
+if($msg = elgg_extract('msg', $vars)) {
+	echo '<p>'.$msg.'</p>';
+}
+
+?>
+<div id="poll-post-body-<?php echo $poll->guid; ?>" class="poll_post_body" style="display:block;">
+<?php echo elgg_view('polls/results_for_widget', array('entity' => $poll)); ?>
+</div>
+


### PR DESCRIPTION
Any user that can see the poll will always get the results, before if you haven't voted but could do so you won't be able to see the results and only got the read only message with no way to toggle to the results.