### PR TITLE
fix gcaccount logout url redirect

### DIFF
--- a/mod/pleio/actions/logout.php
+++ b/mod/pleio/actions/logout.php
@@ -4,7 +4,7 @@ $auth_url = elgg_get_plugin_setting('auth_url', 'pleio');
 $result = logout();
 
 if ($result) {
-    forward($auth_url . "action/logout");
+    forward($auth_url . "logout");
 } else {
     register_error(elgg_echo('logouterror'));
 }


### PR DESCRIPTION
/action/ is an elgg thing, it's just /logout in gcaccount
fixes #2732 